### PR TITLE
`OrderedReactiveCollection` and `ReactiveCollection`.

### DIFF
--- a/ReactiveCollections.xcodeproj/project.pbxproj
+++ b/ReactiveCollections.xcodeproj/project.pbxproj
@@ -48,6 +48,22 @@
 		7DF60EEE1E007DEF0096283B /* Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF60EEC1E007DEF0096283B /* Delta.swift */; };
 		7DF60EEF1E007DEF0096283B /* Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF60EEC1E007DEF0096283B /* Delta.swift */; };
 		7DF60EF01E007DEF0096283B /* Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF60EEC1E007DEF0096283B /* Delta.swift */; };
+		9A37DC681E0C0E0F0075EC2E /* ReactiveCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC671E0C0E0F0075EC2E /* ReactiveCollection.swift */; };
+		9A37DC691E0C0E0F0075EC2E /* ReactiveCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC671E0C0E0F0075EC2E /* ReactiveCollection.swift */; };
+		9A37DC6A1E0C0E0F0075EC2E /* ReactiveCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC671E0C0E0F0075EC2E /* ReactiveCollection.swift */; };
+		9A37DC6B1E0C0E0F0075EC2E /* ReactiveCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC671E0C0E0F0075EC2E /* ReactiveCollection.swift */; };
+		9A37DC6D1E0C0F360075EC2E /* FoundationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC6C1E0C0F360075EC2E /* FoundationExtensions.swift */; };
+		9A37DC6E1E0C0F360075EC2E /* FoundationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC6C1E0C0F360075EC2E /* FoundationExtensions.swift */; };
+		9A37DC6F1E0C0F360075EC2E /* FoundationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC6C1E0C0F360075EC2E /* FoundationExtensions.swift */; };
+		9A37DC701E0C0F360075EC2E /* FoundationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC6C1E0C0F360075EC2E /* FoundationExtensions.swift */; };
+		9A37DC721E0C28AE0075EC2E /* BidirectionalIndexCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC711E0C28AE0075EC2E /* BidirectionalIndexCollection.swift */; };
+		9A37DC731E0C28AE0075EC2E /* BidirectionalIndexCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC711E0C28AE0075EC2E /* BidirectionalIndexCollection.swift */; };
+		9A37DC741E0C28AE0075EC2E /* BidirectionalIndexCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC711E0C28AE0075EC2E /* BidirectionalIndexCollection.swift */; };
+		9A37DC751E0C28AE0075EC2E /* BidirectionalIndexCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC711E0C28AE0075EC2E /* BidirectionalIndexCollection.swift */; };
+		9A37DC771E0C2AC50075EC2E /* Existentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC761E0C2AC50075EC2E /* Existentials.swift */; };
+		9A37DC781E0C2AC50075EC2E /* Existentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC761E0C2AC50075EC2E /* Existentials.swift */; };
+		9A37DC791E0C2AC50075EC2E /* Existentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC761E0C2AC50075EC2E /* Existentials.swift */; };
+		9A37DC7A1E0C2AC50075EC2E /* Existentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A37DC761E0C2AC50075EC2E /* Existentials.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -135,6 +151,10 @@
 		7DE06DD51DFADCE4003303AB /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/tvOS/Result.framework; sourceTree = "<group>"; };
 		7DF60EEC1E007DEF0096283B /* Delta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Delta.swift; sourceTree = "<group>"; };
 		9A37DC651E0B34D70075EC2E /* ReactiveArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReactiveArrayTests.swift; path = ReactiveCollectionsTests/ReactiveArrayTests.swift; sourceTree = "<group>"; };
+		9A37DC671E0C0E0F0075EC2E /* ReactiveCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReactiveCollection.swift; sourceTree = "<group>"; };
+		9A37DC6C1E0C0F360075EC2E /* FoundationExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationExtensions.swift; sourceTree = "<group>"; };
+		9A37DC711E0C28AE0075EC2E /* BidirectionalIndexCollection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BidirectionalIndexCollection.swift; sourceTree = "<group>"; };
+		9A37DC761E0C2AC50075EC2E /* Existentials.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Existentials.swift; sourceTree = "<group>"; };
 		9AFF559E1E0AFEDE006426F4 /* Common.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Common.xcconfig; sourceTree = "<group>"; };
 		9AFF55A01E0AFEDE006426F4 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		9AFF55A11E0AFEDE006426F4 /* Profile.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Profile.xcconfig; sourceTree = "<group>"; };
@@ -279,8 +299,12 @@
 			isa = PBXGroup;
 			children = (
 				7D69AAF71DF9D07800FCB568 /* ReactiveArray.swift */,
+				9A37DC671E0C0E0F0075EC2E /* ReactiveCollection.swift */,
+				9A37DC761E0C2AC50075EC2E /* Existentials.swift */,
+				9A37DC711E0C28AE0075EC2E /* BidirectionalIndexCollection.swift */,
 				7DF60EEC1E007DEF0096283B /* Delta.swift */,
 				7D3D8BE41DF9EAE000E90921 /* Supporting Files */,
+				9A37DC6C1E0C0F360075EC2E /* FoundationExtensions.swift */,
 			);
 			name = ReactiveCollections;
 			path = Sources;
@@ -724,7 +748,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A37DC6D1E0C0F360075EC2E /* FoundationExtensions.swift in Sources */,
+				9A37DC771E0C2AC50075EC2E /* Existentials.swift in Sources */,
+				9A37DC721E0C28AE0075EC2E /* BidirectionalIndexCollection.swift in Sources */,
 				7D69AAF81DF9D07800FCB568 /* ReactiveArray.swift in Sources */,
+				9A37DC681E0C0E0F0075EC2E /* ReactiveCollection.swift in Sources */,
 				7DF60EED1E007DEF0096283B /* Delta.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -741,8 +769,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A37DC7A1E0C2AC50075EC2E /* Existentials.swift in Sources */,
 				7DC1E2DA1DFADF9B00A61745 /* ReactiveArray.swift in Sources */,
+				9A37DC751E0C28AE0075EC2E /* BidirectionalIndexCollection.swift in Sources */,
 				7DF60EF01E007DEF0096283B /* Delta.swift in Sources */,
+				9A37DC6B1E0C0E0F0075EC2E /* ReactiveCollection.swift in Sources */,
+				9A37DC701E0C0F360075EC2E /* FoundationExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -750,8 +782,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A37DC781E0C2AC50075EC2E /* Existentials.swift in Sources */,
 				7DE06DAB1DFADB0F003303AB /* ReactiveArray.swift in Sources */,
+				9A37DC731E0C28AE0075EC2E /* BidirectionalIndexCollection.swift in Sources */,
 				7DF60EEE1E007DEF0096283B /* Delta.swift in Sources */,
+				9A37DC691E0C0E0F0075EC2E /* ReactiveCollection.swift in Sources */,
+				9A37DC6E1E0C0F360075EC2E /* FoundationExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -767,8 +803,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A37DC791E0C2AC50075EC2E /* Existentials.swift in Sources */,
 				7DE06DDA1DFADD69003303AB /* ReactiveArray.swift in Sources */,
+				9A37DC741E0C28AE0075EC2E /* BidirectionalIndexCollection.swift in Sources */,
 				7DF60EEF1E007DEF0096283B /* Delta.swift in Sources */,
+				9A37DC6A1E0C0E0F0075EC2E /* ReactiveCollection.swift in Sources */,
+				9A37DC6F1E0C0F360075EC2E /* FoundationExtensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/BidirectionalIndexCollection.swift
+++ b/Sources/BidirectionalIndexCollection.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public protocol BidirectionalIndexCollection: BidirectionalCollection {
+	// FIXME: (Swift 4.0) Arbitrary requirements
+	// Ideally, this would be written as:
+	// associatedtype Iterator where Iterator.Element: Strideable, Iterator.Element.Stride: SignedInteger
+	associatedtype Iterator
+
+	// FIXME: (Swift 4.0) Arbitrary requirements
+	// Ideally, this would be written as:
+	// associatedtype RangeView: BidirectionalCollection where RangeView.Iterator.Element == CountableRange<Iterator.Element>
+	associatedtype RangeView: BidirectionalCollection
+
+	var rangeView: RangeView { get }
+}
+
+extension IndexSet: BidirectionalIndexCollection {}

--- a/Sources/Delta.swift
+++ b/Sources/Delta.swift
@@ -1,35 +1,28 @@
 import Foundation
 
-public extension IndexSet {
-
-	public static var empty: IndexSet {
-		return IndexSet()
-	}
-}
-
-public struct Delta<Snapshot: Collection, ChangeRepresentation> {
+// FIXME: (Swift 4.0) Arbitrary requirements
+// Ideally, we would have this constraint:
+// Indices.Iterator.Element == Snapshot.Index
+public struct Delta<Snapshot: Collection, Indices: Collection> {
 	public let previous: Snapshot
 	public let current: Snapshot
 
-	public let inserts: ChangeRepresentation
-	public let deletes: ChangeRepresentation
-	public let updates: ChangeRepresentation
+	public let inserts: Indices
+	public let deletes: Indices
+	public let updates: Indices
 }
 
-extension Delta where Snapshot.Iterator.Element: Equatable, ChangeRepresentation: Equatable {
-
-	public static func ==(lhs: Delta<Snapshot, ChangeRepresentation>, rhs: Delta<Snapshot, ChangeRepresentation>) -> Bool {
-
-		guard lhs.inserts == rhs.inserts
-			&& lhs.deletes == rhs.deletes
-			else { return false }
+extension Delta where Snapshot.Iterator.Element: Equatable, Indices: Equatable {
+	public static func ==(lhs: Delta<Snapshot, Indices>, rhs: Delta<Snapshot, Indices>) -> Bool {
+		guard lhs.inserts == rhs.inserts && lhs.deletes == rhs.deletes else {
+			return false
+		}
 
 		return lhs.previous == rhs.previous && lhs.current == rhs.current
 	}
 }
 
 fileprivate extension Collection where Iterator.Element: Equatable {
-
 	fileprivate static func ==(lhs: Self, rhs: Self) -> Bool {
 		guard lhs.count == rhs.count else {
 			return false

--- a/Sources/Existentials.swift
+++ b/Sources/Existentials.swift
@@ -1,0 +1,49 @@
+import ReactiveSwift
+import enum Result.NoError
+
+// FIXME: (Swift 4.0?) Generalized Existentials
+// Ideally, this would be written as:
+// public typealias AnyReactiveCollection<Snapshot, DeltaIndices> = ReactiveCollection where .Snapshot == Snapshot, .DeltaIndices == DeltaIndices
+public final class AnyReactiveCollection<Snapshot: Collection, DeltaIndices: Collection>: ReactiveCollection {
+	private let _signal: () -> Signal<Delta<Snapshot, DeltaIndices>, NoError>
+	private let _producer: () -> SignalProducer<Delta<Snapshot, DeltaIndices>, NoError>
+
+	public var signal: Signal<Delta<Snapshot, DeltaIndices>, NoError> {
+		return _signal()
+	}
+
+	public var producer: SignalProducer<Delta<Snapshot, DeltaIndices>, NoError> {
+		return _producer()
+	}
+
+	init<R: ReactiveCollection>(_ base: R) where R.Snapshot == Snapshot, R.DeltaIndices == DeltaIndices	{
+		_signal = { base.signal }
+		_producer = { base.producer }
+	}
+}
+
+// FIXME: (Swift 4.0?) Generalized Existentials
+// Ideally, this would be written as:
+// public typealias AnyReactiveCollection<Snapshot, DeltaIndices> = OrderedReactiveCollection where .Snapshot == Snapshot, .DeltaIndices == DeltaIndices
+public final class AnyOrderedReactiveCollection<S: RandomAccessCollection, D: BidirectionalIndexCollection>: OrderedReactiveCollection {
+	// FIXME: Swift 3.0.1 cannot infer these paramters. Remove these typealiases
+	//        and rename the type parameters back when it is patched.
+	public typealias Snapshot = S
+	public typealias DeltaIndices = D
+
+	private let _signal: () -> Signal<Delta<S, D>, NoError>
+	private let _producer: () -> SignalProducer<Delta<S, D>, NoError>
+
+	public var signal: Signal<Delta<S, D>, NoError> {
+		return _signal()
+	}
+
+	public var producer: SignalProducer<Delta<S, D>, NoError> {
+		return _producer()
+	}
+
+	init<R: ReactiveCollection>(_ base: R) where R.Snapshot == S, R.DeltaIndices == DeltaIndices	{
+		_signal = { base.signal }
+		_producer = { base.producer }
+	}
+}

--- a/Sources/FoundationExtensions.swift
+++ b/Sources/FoundationExtensions.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public extension IndexSet {
+	public static var empty: IndexSet {
+		return IndexSet()
+	}
+}

--- a/Sources/ReactiveArray.swift
+++ b/Sources/ReactiveArray.swift
@@ -3,20 +3,18 @@ import ReactiveSwift
 import Result
 
 public final class ReactiveArray<Element> {
-
 	public typealias Snapshot = ContiguousArray<Element>
-	public typealias Change = Delta<Snapshot, IndexSet>
+	public typealias DeltaIndices = IndexSet
+	public typealias Delta = ReactiveCollections.Delta<Snapshot, DeltaIndices>
 
-	public let signal: Signal<Change, NoError>
-
+	public let signal: Signal<Delta, NoError>
 	fileprivate var elements: ContiguousArray<Element>
-
-	fileprivate let innerObserver: Observer<Change, NoError>
+	fileprivate let innerObserver: Observer<Delta, NoError>
 
 	public init(_ elements: [Element]) {
 		self.elements = ContiguousArray(elements)
 
-		(signal, innerObserver) = Signal<Change, NoError>.pipe()
+		(signal, innerObserver) = Signal.pipe()
 	}
 
 	public convenience init() {
@@ -29,10 +27,9 @@ public final class ReactiveArray<Element> {
 
 }
 
-extension ReactiveArray {
-
-	public var producer: SignalProducer<Change, NoError> {
-		return SignalProducer<Change, NSError>.attempt { [weak self] in
+extension ReactiveArray: OrderedReactiveCollection {
+	public var producer: SignalProducer<Delta, NoError> {
+		return SignalProducer<Delta, NSError>.attempt { [weak self] in
 			guard let `self` = self
 				else { return .failure(NSError(domain: "org.RACCommunity.ReactiveCollections", code: 0, userInfo: nil)) }
 

--- a/Sources/ReactiveCollection.swift
+++ b/Sources/ReactiveCollection.swift
@@ -1,0 +1,31 @@
+import ReactiveSwift
+import enum Result.NoError
+
+public protocol ReactiveCollection: class {
+	/// A type that snapshots the content of the collection at an instance of
+	/// time.
+	associatedtype Snapshot: Collection
+
+	// FIXME: (Swift 4.0) Arbitrary requirements
+	// Ideally, this would be written as:
+	// associatedtype DeltaIndices: Collection where DeltaIndices.Iterator.Element == Snapshot.Index
+
+	/// A type that holds indices of changes in a collection delta.
+	associatedtype DeltaIndices: Collection
+
+	/// A Signal that emits subsequent deltas of the collection.
+	var signal: Signal<Delta<Snapshot, DeltaIndices>, NoError> { get }
+
+	/// A SignalProducer that emits the latest content of the collection as a
+	/// delta when started, followed by all subsequent deltas of the collection.
+	var producer: SignalProducer<Delta<Snapshot, DeltaIndices>, NoError> { get }
+}
+
+public protocol OrderedReactiveCollection: ReactiveCollection {
+	/// A type that snapshots the content of the collection at an instance of
+	/// time.
+	associatedtype Snapshot: RandomAccessCollection
+
+	/// A type that holds indices of changes in a collection delta.
+	associatedtype DeltaIndices: BidirectionalIndexCollection
+}

--- a/Tests/ReactiveCollectionsTests/ReactiveArrayTests.swift
+++ b/Tests/ReactiveCollectionsTests/ReactiveArrayTests.swift
@@ -6,7 +6,7 @@ import Result
 
 class ReactiveArrayTests: XCTestCase {
 
-	typealias Change<T> = ReactiveArray<T>.Change
+	typealias Delta<T> = ReactiveArray<T>.Delta
 
 	// MARK: - Initializers
 
@@ -97,8 +97,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_subscripting_replace_at_head() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -124,8 +124,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_replace_range() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -196,8 +196,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_append() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -221,8 +221,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_append_contents_of() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -248,8 +248,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_insert_at_index() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -288,8 +288,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_insert_contents_of() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -315,8 +315,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_all() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -340,8 +340,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_all_and_keep_capacity() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -365,8 +365,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_first() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -390,8 +390,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_first2() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -415,8 +415,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_first_all() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -440,8 +440,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_last() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -465,8 +465,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_last2() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -490,8 +490,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_last_all() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -515,8 +515,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_at_index() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -540,8 +540,8 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_remove_subrange() {
 
-		var changes: [Change<Int>] = []
-		var expectedChanges: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
+		var expectedChanges: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -567,7 +567,7 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_producer() {
 
-		var changes: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -577,7 +577,7 @@ class ReactiveArrayTests: XCTestCase {
 
 		array.removeAll()
 
-		let expectedChanges: [Change<Int>] = [
+		let expectedChanges: [Delta<Int>] = [
 			Delta(
 				previous: [],
 				current: [1, 2, 3],
@@ -606,7 +606,7 @@ class ReactiveArrayTests: XCTestCase {
 
 	func test_producer_with_up_to_date_changes() {
 
-		var changes: [Change<Int>] = []
+		var changes: [Delta<Int>] = []
 
 		let array = ReactiveArray([1, 2, 3])
 
@@ -618,7 +618,7 @@ class ReactiveArrayTests: XCTestCase {
 
 		array.removeAll()
 
-		let expectedChanges: [Change<Int>] = [
+		let expectedChanges: [Delta<Int>] = [
 			Delta(
 				previous: [],
 				current: [1, 2, 3, 4],
@@ -705,8 +705,8 @@ extension ReactiveArrayTests {
 // MARK: - Helpers
 
 func XCTAssertEqual<T>(
-	_ expression1: @autoclosure () -> [ReactiveArray<T>.Change],
-	_ expression2: @autoclosure () -> [ReactiveArray<T>.Change],
+	_ expression1: @autoclosure () -> [ReactiveArray<T>.Delta],
+	_ expression2: @autoclosure () -> [ReactiveArray<T>.Delta],
 	_ message: @autoclosure () -> String = "",
 	file: StaticString = #file,
 	line: UInt = #line)
@@ -720,8 +720,8 @@ func XCTAssertEqual<T>(
 }
 
 func XCTAssertEqual<T>(
-	_ expression1: @autoclosure () -> ReactiveArray<T>.Change,
-	_ expression2: @autoclosure () -> ReactiveArray<T>.Change,
+	_ expression1: @autoclosure () -> ReactiveArray<T>.Delta,
+	_ expression2: @autoclosure () -> ReactiveArray<T>.Delta,
 	_ message: @autoclosure () -> String = "",
 	file: StaticString = #file,
 	line: UInt = #line)


### PR DESCRIPTION
1. The protocols do not inherit any Standard Library collection protocols. As the protocol is to define an interface **for observing the collection**, it might be better to hide all the direct access interface to force observers to rely on the `Delta` anyway for thread safety.

   Specifically, even if all the _calls_ are made thread safe, the indexes are not guaranteed to be valid due to concurrent mutations.

1. `ReactiveCollection.DeltaIndices` is not required to be `ReactiveCollection.Snapshot.Indices` for the flexibility in representation.