### PR TITLE
UITableView data source

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "ReactiveCocoa/ReactiveSwift" ~> 1.0
+github "ReactiveCocoa/ReactiveCocoa" ~> 5.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,6 @@
 github "Quick/Nimble" "v6.1.0"
 github "Quick/Quick" "v1.1.0"
+github "ReactiveCocoa/ReactiveCocoa" "5.0.3"
 github "ReactiveCocoa/ReactiveSwift" "1.1.1"
 github "antitypical/Result" "3.2.1"
 github "jspahrsummers/xcconfigs" "0.10"

--- a/Package.pins
+++ b/Package.pins
@@ -2,6 +2,18 @@
   "autoPin": true,
   "pins": [
     {
+      "package": "Nimble",
+      "reason": null,
+      "repositoryURL": "https://github.com/Quick/Nimble.git",
+      "version": "6.1.0"
+    },
+    {
+      "package": "Quick",
+      "reason": null,
+      "repositoryURL": "https://github.com/Quick/Quick.git",
+      "version": "1.1.0"
+    },
+    {
       "package": "ReactiveSwift",
       "reason": null,
       "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift.git",

--- a/Package.swift
+++ b/Package.swift
@@ -18,5 +18,11 @@ let package = Package(
             ]
         }
 	return deps
-    }()
+    }(),
+    exclude: [
+        "Sources/ReactiveCollections/UIKit",
+        "Sources/ReactiveCollections/AppKit",
+        "Tests/UIKitExtensionsTests",
+        "Tests/AppKitExtensionsTests"
+    ]
 )

--- a/ReactiveCollections.podspec
+++ b/ReactiveCollections.podspec
@@ -14,5 +14,9 @@ Pod::Spec.new do |s|
 
   # Directory glob for all Swift files
   s.source_files  = "Sources/*.{swift}"
-  s.dependency 'ReactiveSwift', '~> 1.0'
+  s.osx.source_files = "AppKit/*.{swift}"
+  s.ios.source_files = "UIKit/*.{swift}"
+  s.tvos.source_files = "UIKit/*.{swift}"
+
+  s.dependency 'ReactiveCocoa', '~> 5.0'
 end

--- a/ReactiveCollections.xcodeproj/project.pbxproj
+++ b/ReactiveCollections.xcodeproj/project.pbxproj
@@ -48,10 +48,14 @@
 		7DF60EEE1E007DEF0096283B /* Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF60EEC1E007DEF0096283B /* Delta.swift */; };
 		7DF60EEF1E007DEF0096283B /* Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF60EEC1E007DEF0096283B /* Delta.swift */; };
 		7DF60EF01E007DEF0096283B /* Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF60EEC1E007DEF0096283B /* Delta.swift */; };
-		9ADC56471E9E662F0049C090 /* StdlibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */; };
-		9ADC56481E9E662F0049C090 /* StdlibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */; };
-		9ADC56491E9E662F0049C090 /* StdlibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */; };
-		9ADC564A1E9E662F0049C090 /* StdlibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */; };
+		9A03F8901EC98BA3000B566F /* DataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A03F88F1EC98BA3000B566F /* DataSourceSpec.swift */; };
+		9A03F8911EC98BA3000B566F /* DataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A03F88F1EC98BA3000B566F /* DataSourceSpec.swift */; };
+		9A03F8921EC98BA3000B566F /* DataSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A03F88F1EC98BA3000B566F /* DataSourceSpec.swift */; };
+		9A9B7A1B1EB346D500ED2401 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B7A1A1EB346D500ED2401 /* DataSource.swift */; };
+		9A9B7A1C1EB346D500ED2401 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B7A1A1EB346D500ED2401 /* DataSource.swift */; };
+		9A9B7A1D1EB346D500ED2401 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B7A1A1EB346D500ED2401 /* DataSource.swift */; };
+		9A9B7A1E1EB346D500ED2401 /* DataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9B7A1A1EB346D500ED2401 /* DataSource.swift */; };
+		9ADC56301E9D2C130049C090 /* UITableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC562F1E9D2C130049C090 /* UITableView.swift */; };
 		9ADC56381E9D2DC60049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56371E9D2DB90049C090 /* ReactiveCocoa.framework */; };
 		9ADC56391E9D2DCB0049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56361E9D2DB00049C090 /* ReactiveCocoa.framework */; };
 		9ADC563A1E9D2DD00049C090 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9ADC56361E9D2DB00049C090 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -62,6 +66,7 @@
 		9ADC56411E9D2E090049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56341E9D2D9C0049C090 /* ReactiveCocoa.framework */; };
 		9ADC56421E9D2E0B0049C090 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9ADC56341E9D2D9C0049C090 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9ADC56431E9D2E0F0049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56341E9D2D9C0049C090 /* ReactiveCocoa.framework */; };
+		9ADC56451E9D2F2E0049C090 /* UITableViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC56441E9D2F2E0049C090 /* UITableViewSpec.swift */; };
 		9AF7E1861E9A8CB000F6672B /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AF7E1841E9A8C9F00F6672B /* Nimble.framework */; };
 		9AF7E1871E9A8CB000F6672B /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AF7E1851E9A8C9F00F6672B /* Quick.framework */; };
 		9AF7E1881E9A8CB400F6672B /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9AF7E1841E9A8C9F00F6672B /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -174,10 +179,14 @@
 		7DF60EEC1E007DEF0096283B /* Delta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Delta.swift; sourceTree = "<group>"; };
 		9A37DC651E0B34D70075EC2E /* ReactiveArraySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReactiveArraySpec.swift; path = ReactiveCollectionsTests/ReactiveArraySpec.swift; sourceTree = "<group>"; };
 		9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StdlibExtensions.swift; sourceTree = "<group>"; };
+		9A03F88F1EC98BA3000B566F /* DataSourceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = DataSourceSpec.swift; path = ReactiveCollectionsTests/DataSourceSpec.swift; sourceTree = "<group>"; };
+		9A9B7A1A1EB346D500ED2401 /* DataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataSource.swift; sourceTree = "<group>"; };
+		9ADC562F1E9D2C130049C090 /* UITableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UITableView.swift; path = UIKit/UITableView.swift; sourceTree = SOURCE_ROOT; };
 		9ADC56341E9D2D9C0049C090 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/iOS/ReactiveCocoa.framework; sourceTree = "<group>"; };
 		9ADC56351E9D2DA40049C090 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/Mac/ReactiveCocoa.framework; sourceTree = "<group>"; };
 		9ADC56361E9D2DB00049C090 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/tvOS/ReactiveCocoa.framework; sourceTree = "<group>"; };
 		9ADC56371E9D2DB90049C090 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/watchOS/ReactiveCocoa.framework; sourceTree = "<group>"; };
+		9ADC56441E9D2F2E0049C090 /* UITableViewSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UITableViewSpec.swift; path = UIKitExtensionsTests/UITableViewSpec.swift; sourceTree = "<group>"; };
 		9AF7E17E1E9A8BE100F6672B /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
 		9AF7E1801E9A8C8A00F6672B /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
 		9AF7E1811E9A8C8A00F6672B /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
@@ -316,6 +325,7 @@
 		7D69AAD31DF9CEE500FCB568 = {
 			isa = PBXGroup;
 			children = (
+				9AF7E1721E9A65C400F6672B /* UIKit */,
 				7D69AADF1DF9CEE500FCB568 /* ReactiveCollections */,
 				7D69AAEA1DF9CEE500FCB568 /* Tests */,
 				9AFF559C1E0AFEC2006426F4 /* Configurations */,
@@ -342,6 +352,7 @@
 		7D69AADF1DF9CEE500FCB568 /* ReactiveCollections */ = {
 			isa = PBXGroup;
 			children = (
+				9A9B7A1A1EB346D500ED2401 /* DataSource.swift */,
 				7D69AAF71DF9D07800FCB568 /* ReactiveArray.swift */,
 				7DF60EEC1E007DEF0096283B /* Delta.swift */,
 				7D3D8BE41DF9EAE000E90921 /* Supporting Files */,
@@ -356,6 +367,8 @@
 				9AF7E17E1E9A8BE100F6672B /* LinuxMain.swift */,
 				9A37DC651E0B34D70075EC2E /* ReactiveArraySpec.swift */,
 				9AF7E19C1E9C9EAC00F6672B /* Delta+NimbleMatcher.swift */,
+				9ADC56441E9D2F2E0049C090 /* UITableViewSpec.swift */,
+				9A03F88F1EC98BA3000B566F /* DataSourceSpec.swift */,
 				7D3D8BE51DF9EB1D00E90921 /* Supporting Files */,
 			);
 			path = Tests;
@@ -416,6 +429,15 @@
 				7DE06DD51DFADCE4003303AB /* Result.framework */,
 			);
 			name = tvOS;
+			sourceTree = "<group>";
+		};
+		9AF7E1721E9A65C400F6672B /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				9ADC562F1E9D2C130049C090 /* UITableView.swift */,
+			);
+			name = UIKit;
+			path = Sources;
 			sourceTree = "<group>";
 		};
 		9AFF559C1E0AFEC2006426F4 /* Configurations */ = {
@@ -801,6 +823,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				7D69AAF81DF9D07800FCB568 /* ReactiveArray.swift in Sources */,
+				9ADC56301E9D2C130049C090 /* UITableView.swift in Sources */,
+				9A9B7A1B1EB346D500ED2401 /* DataSource.swift in Sources */,
 				7DF60EED1E007DEF0096283B /* Delta.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -811,6 +835,8 @@
 			files = (
 				9AF7E19D1E9C9EAC00F6672B /* Delta+NimbleMatcher.swift in Sources */,
 				7D85106C1E0BDFC200A57CC9 /* ReactiveArraySpec.swift in Sources */,
+				9A03F8901EC98BA3000B566F /* DataSourceSpec.swift in Sources */,
+				9ADC56451E9D2F2E0049C090 /* UITableViewSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -818,6 +844,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A9B7A1E1EB346D500ED2401 /* DataSource.swift in Sources */,
 				7DC1E2DA1DFADF9B00A61745 /* ReactiveArray.swift in Sources */,
 				7DF60EF01E007DEF0096283B /* Delta.swift in Sources */,
 			);
@@ -827,6 +854,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A9B7A1C1EB346D500ED2401 /* DataSource.swift in Sources */,
 				7DE06DAB1DFADB0F003303AB /* ReactiveArray.swift in Sources */,
 				7DF60EEE1E007DEF0096283B /* Delta.swift in Sources */,
 			);
@@ -836,6 +864,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A03F8911EC98BA3000B566F /* DataSourceSpec.swift in Sources */,
 				9AF7E19E1E9C9EAC00F6672B /* Delta+NimbleMatcher.swift in Sources */,
 				7D85106D1E0BDFCD00A57CC9 /* ReactiveArraySpec.swift in Sources */,
 			);
@@ -845,6 +874,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A9B7A1D1EB346D500ED2401 /* DataSource.swift in Sources */,
 				7DE06DDA1DFADD69003303AB /* ReactiveArray.swift in Sources */,
 				7DF60EEF1E007DEF0096283B /* Delta.swift in Sources */,
 			);
@@ -854,6 +884,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9A03F8921EC98BA3000B566F /* DataSourceSpec.swift in Sources */,
 				9AF7E19F1E9C9EAC00F6672B /* Delta+NimbleMatcher.swift in Sources */,
 				7D85106E1E0BDFD400A57CC9 /* ReactiveArraySpec.swift in Sources */,
 			);

--- a/ReactiveCollections.xcodeproj/project.pbxproj
+++ b/ReactiveCollections.xcodeproj/project.pbxproj
@@ -48,6 +48,20 @@
 		7DF60EEE1E007DEF0096283B /* Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF60EEC1E007DEF0096283B /* Delta.swift */; };
 		7DF60EEF1E007DEF0096283B /* Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF60EEC1E007DEF0096283B /* Delta.swift */; };
 		7DF60EF01E007DEF0096283B /* Delta.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF60EEC1E007DEF0096283B /* Delta.swift */; };
+		9ADC56471E9E662F0049C090 /* StdlibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */; };
+		9ADC56481E9E662F0049C090 /* StdlibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */; };
+		9ADC56491E9E662F0049C090 /* StdlibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */; };
+		9ADC564A1E9E662F0049C090 /* StdlibExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */; };
+		9ADC56381E9D2DC60049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56371E9D2DB90049C090 /* ReactiveCocoa.framework */; };
+		9ADC56391E9D2DCB0049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56361E9D2DB00049C090 /* ReactiveCocoa.framework */; };
+		9ADC563A1E9D2DD00049C090 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9ADC56361E9D2DB00049C090 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9ADC563B1E9D2DD30049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56361E9D2DB00049C090 /* ReactiveCocoa.framework */; };
+		9ADC563E1E9D2DF80049C090 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9ADC56351E9D2DA40049C090 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9ADC563F1E9D2E000049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56351E9D2DA40049C090 /* ReactiveCocoa.framework */; };
+		9ADC56401E9D2E050049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56351E9D2DA40049C090 /* ReactiveCocoa.framework */; };
+		9ADC56411E9D2E090049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56341E9D2D9C0049C090 /* ReactiveCocoa.framework */; };
+		9ADC56421E9D2E0B0049C090 /* ReactiveCocoa.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9ADC56341E9D2D9C0049C090 /* ReactiveCocoa.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9ADC56431E9D2E0F0049C090 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9ADC56341E9D2D9C0049C090 /* ReactiveCocoa.framework */; };
 		9AF7E1861E9A8CB000F6672B /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AF7E1841E9A8C9F00F6672B /* Nimble.framework */; };
 		9AF7E1871E9A8CB000F6672B /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AF7E1851E9A8C9F00F6672B /* Quick.framework */; };
 		9AF7E1881E9A8CB400F6672B /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9AF7E1841E9A8C9F00F6672B /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -97,6 +111,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				7D3D8BE11DF9D23F00E90921 /* ReactiveCollections.framework in CopyFiles */,
+				9ADC56421E9D2E0B0049C090 /* ReactiveCocoa.framework in CopyFiles */,
 				7D3D8BE21DF9D23F00E90921 /* ReactiveSwift.framework in CopyFiles */,
 				7D3D8BE31DF9D23F00E90921 /* Result.framework in CopyFiles */,
 				9AF7E1881E9A8CB400F6672B /* Nimble.framework in CopyFiles */,
@@ -111,6 +126,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				7DE06DB51DFADBC3003303AB /* ReactiveCollections.framework in CopyFiles */,
+				9ADC563E1E9D2DF80049C090 /* ReactiveCocoa.framework in CopyFiles */,
 				7DE06DB61DFADBCC003303AB /* ReactiveSwift.framework in CopyFiles */,
 				7DE06DB71DFADBCC003303AB /* Result.framework in CopyFiles */,
 				9AF7E18C1E9A8CBE00F6672B /* Nimble.framework in CopyFiles */,
@@ -124,6 +140,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				9ADC563A1E9D2DD00049C090 /* ReactiveCocoa.framework in CopyFiles */,
 				7DE06DDF1DFADD9B003303AB /* ReactiveCollections.framework in CopyFiles */,
 				7DE06DE01DFADDA0003303AB /* ReactiveSwift.framework in CopyFiles */,
 				7DE06DE11DFADDA0003303AB /* Result.framework in CopyFiles */,
@@ -156,6 +173,11 @@
 		7DE06DD51DFADCE4003303AB /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/tvOS/Result.framework; sourceTree = "<group>"; };
 		7DF60EEC1E007DEF0096283B /* Delta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Delta.swift; sourceTree = "<group>"; };
 		9A37DC651E0B34D70075EC2E /* ReactiveArraySpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ReactiveArraySpec.swift; path = ReactiveCollectionsTests/ReactiveArraySpec.swift; sourceTree = "<group>"; };
+		9ADC56461E9E662F0049C090 /* StdlibExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StdlibExtensions.swift; sourceTree = "<group>"; };
+		9ADC56341E9D2D9C0049C090 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/iOS/ReactiveCocoa.framework; sourceTree = "<group>"; };
+		9ADC56351E9D2DA40049C090 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/Mac/ReactiveCocoa.framework; sourceTree = "<group>"; };
+		9ADC56361E9D2DB00049C090 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/tvOS/ReactiveCocoa.framework; sourceTree = "<group>"; };
+		9ADC56371E9D2DB90049C090 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/watchOS/ReactiveCocoa.framework; sourceTree = "<group>"; };
 		9AF7E17E1E9A8BE100F6672B /* LinuxMain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxMain.swift; sourceTree = "<group>"; };
 		9AF7E1801E9A8C8A00F6672B /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
 		9AF7E1811E9A8C8A00F6672B /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
@@ -196,6 +218,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9ADC56431E9D2E0F0049C090 /* ReactiveCocoa.framework in Frameworks */,
 				7D69AAFE1DF9D0E200FCB568 /* ReactiveSwift.framework in Frameworks */,
 				7D69AAFF1DF9D0E200FCB568 /* Result.framework in Frameworks */,
 			);
@@ -206,6 +229,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7D69AAE71DF9CEE500FCB568 /* ReactiveCollections.framework in Frameworks */,
+				9ADC56411E9D2E090049C090 /* ReactiveCocoa.framework in Frameworks */,
 				7D69AB001DF9D11900FCB568 /* ReactiveSwift.framework in Frameworks */,
 				7D69AB011DF9D11900FCB568 /* Result.framework in Frameworks */,
 				9AF7E1861E9A8CB000F6672B /* Nimble.framework in Frameworks */,
@@ -219,6 +243,7 @@
 			files = (
 				7DC1E2DD1DFADFA500A61745 /* ReactiveSwift.framework in Frameworks */,
 				7DC1E2DE1DFADFA500A61745 /* Result.framework in Frameworks */,
+				9ADC56381E9D2DC60049C090 /* ReactiveCocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -228,6 +253,7 @@
 			files = (
 				7DE06DAC1DFADB19003303AB /* ReactiveSwift.framework in Frameworks */,
 				7DE06DAD1DFADB19003303AB /* Result.framework in Frameworks */,
+				9ADC56401E9D2E050049C090 /* ReactiveCocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -236,6 +262,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7DE06D9C1DFADA84003303AB /* ReactiveCollections.framework in Frameworks */,
+				9ADC563F1E9D2E000049C090 /* ReactiveCocoa.framework in Frameworks */,
 				7DE06DB11DFADB9F003303AB /* ReactiveSwift.framework in Frameworks */,
 				7DE06DB21DFADB9F003303AB /* Result.framework in Frameworks */,
 				9AF7E18A1E9A8CBB00F6672B /* Nimble.framework in Frameworks */,
@@ -249,6 +276,7 @@
 			files = (
 				7DE06DD61DFADCE4003303AB /* ReactiveSwift.framework in Frameworks */,
 				7DE06DD71DFADCE4003303AB /* Result.framework in Frameworks */,
+				9ADC56391E9D2DCB0049C090 /* ReactiveCocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -257,6 +285,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7DE06DC61DFADCAF003303AB /* ReactiveCollections.framework in Frameworks */,
+				9ADC563B1E9D2DD30049C090 /* ReactiveCocoa.framework in Frameworks */,
 				7DE06DDC1DFADD8B003303AB /* ReactiveSwift.framework in Frameworks */,
 				7DE06DDD1DFADD8B003303AB /* Result.framework in Frameworks */,
 				9AF7E1901E9A8CCA00F6672B /* Nimble.framework in Frameworks */,
@@ -346,6 +375,7 @@
 		7DC1E2DF1DFAE01800A61745 /* watchOS */ = {
 			isa = PBXGroup;
 			children = (
+				9ADC56371E9D2DB90049C090 /* ReactiveCocoa.framework */,
 				7DC1E2DB1DFADFA500A61745 /* ReactiveSwift.framework */,
 				7DC1E2DC1DFADFA500A61745 /* Result.framework */,
 			);
@@ -355,6 +385,7 @@
 		7DE06DAF1DFADB7C003303AB /* macOS */ = {
 			isa = PBXGroup;
 			children = (
+				9ADC56351E9D2DA40049C090 /* ReactiveCocoa.framework */,
 				9AF7E1821E9A8C9700F6672B /* Nimble.framework */,
 				9AF7E1831E9A8C9700F6672B /* Quick.framework */,
 				7DE06D7C1DFAD8E9003303AB /* ReactiveSwift.framework */,
@@ -366,6 +397,7 @@
 		7DE06DB01DFADB82003303AB /* iOS */ = {
 			isa = PBXGroup;
 			children = (
+				9ADC56341E9D2D9C0049C090 /* ReactiveCocoa.framework */,
 				9AF7E1841E9A8C9F00F6672B /* Nimble.framework */,
 				9AF7E1851E9A8C9F00F6672B /* Quick.framework */,
 				7D69AAFC1DF9D0E200FCB568 /* ReactiveSwift.framework */,
@@ -377,6 +409,7 @@
 		7DE06DD81DFADCE8003303AB /* tvOS */ = {
 			isa = PBXGroup;
 			children = (
+				9ADC56361E9D2DB00049C090 /* ReactiveCocoa.framework */,
 				9AF7E1801E9A8C8A00F6672B /* Nimble.framework */,
 				9AF7E1811E9A8C8A00F6672B /* Quick.framework */,
 				7DE06DD41DFADCE4003303AB /* ReactiveSwift.framework */,
@@ -1123,6 +1156,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -1140,6 +1174,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -1350,6 +1385,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -1536,6 +1572,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/Mac",
+					"$(PROJECT_DIR)/Carthage/Build/tvOS",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/Sources/DataSource.swift
+++ b/Sources/DataSource.swift
@@ -1,0 +1,299 @@
+import Foundation
+import ReactiveSwift
+import Result
+
+// FIXME: Swift 4 Associated Type Constraints
+//
+// open class DataSource<Delta>: NSObject
+// where Delta: IndexingDelta, Delta.Snapshot.Element: IndexingDeltaSection
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+public typealias _DataSourceBase = NSObject
+#else
+open class _DataSourceBase {}
+#endif
+
+open class DataSource<Delta: IndexingDelta>: _DataSourceBase
+where Delta.IndexPairs.Iterator.Element == (Delta.Snapshot.Index,Delta.Snapshot.Index),
+      Delta.Snapshot.Index == Delta.ChangeRepresentation.Iterator.Element,
+      Delta.Snapshot.IndexDistance.Stride: SignedInteger,
+      Delta.Snapshot.Iterator.Element: IndexingDeltaSection,
+      Delta.Snapshot.Iterator.Element.Delta: IndexingDelta,
+      Delta.Snapshot.Iterator.Element.Delta.IndexPairs.Iterator.Element == (Delta.Snapshot.Iterator.Element.Delta.Snapshot.Index, Delta.Snapshot.Iterator.Element.Delta.Snapshot.Index),
+      Delta.Snapshot.Iterator.Element.Delta.Snapshot.Index == Delta.Snapshot.Iterator.Element.Delta.ChangeRepresentation.Iterator.Element,
+      Delta.Snapshot.Iterator.Element.Delta.Snapshot.IndexDistance.Stride: SignedInteger {
+	public enum Event {
+		case reloadAll
+		case reloadSections(IndexSet)
+		case insertSections(IndexSet)
+		case deleteSections(IndexSet)
+		case moveSection(source: Int, destination: Int)
+		case insertRows(IndexSet, section: Int)
+		case deleteRows(IndexSet, section: Int)
+		case reloadRows(IndexSet, section: Int)
+		case moveRow(source: Int, destination: Int, section: Int)
+	}
+
+	private var sections: ContiguousArray<Section>
+	private var producer: SignalProducer<Delta, NoError>?
+	private let canTraverseBidirectionally: Bool
+
+	public var sectionCount: Int {
+		return sections.count
+	}
+
+	public init(deltas producer: SignalProducer<Delta, NoError>, canInnerTraverseBidirectionally: Bool = false) {
+		self.sections = []
+		self.producer = producer
+		self.canTraverseBidirectionally = canInnerTraverseBidirectionally
+	}
+
+	deinit {
+		for section in sections {
+			section.disposable.dispose()
+		}
+	}
+
+	public final func rowCount(section: Int) -> Int {
+		return sections[section].count
+	}
+
+	public final subscript(section: Int, row: Int) -> Delta.Snapshot.Iterator.Element.Delta.Snapshot.Iterator.Element {
+		return sections[section][row]
+	}
+
+	open func update(_ action: ((Event) -> Void) -> Void) {
+		fatalError("Subclasses must implement this method.")
+	}
+
+	public final func start() -> Disposable? {
+		guard let producer = self.producer else {
+			return nil
+		}
+
+		self.producer = nil
+
+		// Force the `UITableView` to flush the default data source.
+		self.update { handler in
+			handler(.reloadAll)
+		}
+
+		return producer.startWithValues { delta in
+			func insertSection(
+				_ deltaProducer: SignalProducer<Delta.Snapshot.Iterator.Element.Delta, NoError>,
+				at offset: Int
+				) {
+				let section = Section(deltaProducer, dataSource: self, initialOffset: offset, canTraverseBidirectionally: self.canTraverseBidirectionally)
+				self.sections.insert(section, at: offset)
+			}
+
+			self.update { handler in
+				var deleteOffsets = IndexSet()
+				var moveOffsets: [(Section, Int)] = []
+
+				if !delta.deletes.isEmpty {
+					var previousIndex = delta.previous.startIndex
+					var offset = 0
+
+					for index in delta.deletes {
+						offset += Int(delta.previous.distance(from: previousIndex, to: index).toIntMax())
+						previousIndex = index
+
+						deleteOffsets.insert(offset)
+
+						let section = self.sections[offset]
+						section.disposable.dispose()
+					}
+
+					handler(.deleteSections(deleteOffsets))
+				}
+
+				if !delta.moves.isEmpty {
+					moveOffsets.reserveCapacity(Int(delta.moves.count.toIntMax()))
+
+					var previousIndex1 = delta.previous.startIndex
+					var previousIndex2 = delta.current.startIndex
+
+					var offset1 = 0
+					var offset2 = 0
+
+					for (previous, current) in delta.moves {
+						offset1 += Int(delta.previous.distance(from: previousIndex1, to: previous).toIntMax())
+						previousIndex1 = previous
+
+						offset2 += Int(delta.current.distance(from: previousIndex2, to: current).toIntMax())
+						previousIndex2 = current
+
+						deleteOffsets.insert(offset1)
+						moveOffsets.append((self.sections[offset1], offset2))
+
+						handler(.moveSection(source: offset1, destination: offset2))
+					}
+				}
+
+				if !deleteOffsets.isEmpty {
+					for index in deleteOffsets.reversed() {
+						self.sections.remove(at: index)
+					}
+				}
+
+				if !moveOffsets.isEmpty {
+					moveOffsets.sort { $0.1 < $1.1 }
+
+					for (section, index) in moveOffsets {
+						self.sections.insert(section, at: index)
+					}
+				}
+
+				if !delta.inserts.isEmpty {
+					var previousIndex = delta.current.startIndex
+					var offset = 0
+					var inserted = IndexSet()
+
+					for index in delta.inserts {
+						offset += Int(delta.current.distance(from: previousIndex, to: index).toIntMax())
+						previousIndex = index
+
+						inserted.insert(offset)
+						insertSection(delta.current[index].deltas, at: offset)
+					}
+
+					handler(.insertSections(inserted))
+				}
+
+				if !delta.updates.isEmpty {
+					var previousIndex = delta.previous.startIndex
+					var offset = 0
+					var reloaded = IndexSet()
+
+					for index in delta.updates {
+						offset += Int(delta.previous.distance(from: previousIndex, to: index).toIntMax())
+						previousIndex = index
+
+						reloaded.insert(offset)
+
+						let old = self.sections.remove(at: offset)
+						old.disposable.dispose()
+
+						insertSection(delta.current[index].deltas, at: offset)
+					}
+					
+					handler(.reloadSections(reloaded))
+				}
+				
+				for offset in self.sections.startIndex ..< self.sections.endIndex {
+					self.sections[offset].sectionOffset = offset
+				}
+			}
+		}
+	}
+}
+
+extension DataSource {
+	fileprivate final class Section {
+		fileprivate typealias LocalDelta = Delta.Snapshot.Iterator.Element.Delta
+
+		private var current: LocalDelta.Snapshot!
+		private var position: (offset: Int, index: LocalDelta.Snapshot.Index)?
+		private unowned let dataSource: DataSource
+
+		fileprivate var disposable: Disposable!
+		fileprivate var sectionOffset: Int
+		private let canTraverseBidirectionally: Bool
+
+		var count: Int {
+			return Int(current.count.toIntMax())
+		}
+
+		init(_ producer: SignalProducer<LocalDelta, NoError>, dataSource: DataSource, initialOffset: Int, canTraverseBidirectionally: Bool) {
+			self.current = nil
+			self.dataSource = dataSource
+			self.sectionOffset = initialOffset
+			self.canTraverseBidirectionally = canTraverseBidirectionally
+			self.disposable = producer
+				.on(value: { delta in
+					self.current = delta.current
+					self.position = nil
+				})
+				.skip(first: 1)
+				.startWithValues { delta in
+					let currentCount = delta.current.count.toIntMax()
+					let previousCount = delta.previous.count.toIntMax()
+
+					if currentCount == 0 || previousCount == 0 || currentCount == previousCount {
+						self.current = delta.current
+						self.dataSource.update { handler in
+							handler(.reloadSections(IndexSet(integer: self.sectionOffset)))
+						}
+						return
+					}
+
+					self.dataSource.update { handler in
+						if !delta.deletes.isEmpty {
+							handler(.deleteRows(LocalDelta.computeOffsets(for: delta.deletes, in: delta.previous),
+							                    section: self.sectionOffset))
+						}
+
+						if !delta.updates.isEmpty {
+							handler(.reloadRows(LocalDelta.computeOffsets(for: delta.updates, in: delta.current),
+							                    section: self.sectionOffset))
+						}
+
+						if !delta.inserts.isEmpty {
+							handler(.insertRows(LocalDelta.computeOffsets(for: delta.inserts, in: delta.current),
+							                    section: self.sectionOffset))
+						}
+
+						if !delta.moves.isEmpty {
+							let moveOffsets = LocalDelta.computeOffsetPairs(from: delta.moves, in: (delta.previous, delta.current))
+							for (previous, current) in moveOffsets {
+								handler(.moveRow(source: previous, destination: current, section: self.sectionOffset))
+							}
+						}
+					}
+				}
+		}
+
+		subscript(row: Int) -> LocalDelta.Snapshot.Iterator.Element {
+			let index: LocalDelta.Snapshot.Index
+
+			if let position = position, canTraverseBidirectionally || position.offset < row {
+				let offset = LocalDelta.Snapshot.IndexDistance((row - position.offset).toIntMax())
+				index = current.index(position.index, offsetBy: offset)
+			} else {
+				let offset = LocalDelta.Snapshot.IndexDistance(row.toIntMax())
+				index = current.index(current.startIndex, offsetBy: offset)
+			}
+
+			position = (offset: row, index: index)
+
+			return current[index]
+		}
+	}
+}
+
+extension DataSource.Event: Equatable {
+	public static func ==(left: DataSource<Delta>.Event, right: DataSource<Delta>.Event) -> Bool {
+		switch (left, right) {
+		case (.reloadAll, .reloadAll):
+			return true
+		case let (.reloadSections(left), .reloadSections(right)):
+			return left == right
+		case let (.insertSections(left), .insertSections(right)):
+			return left == right
+		case let (.deleteSections(left), .deleteSections(right)):
+			return left == right
+		case let (.moveSection(leftSource, leftDestination), .moveSection(rightSource, rightDestination)):
+			return leftSource == rightSource && leftDestination == rightDestination
+		case let (.insertRows(leftRows, leftSection), .insertRows(rightRows, rightSection)):
+			return leftSection == rightSection && leftRows == rightRows
+		case let (.deleteRows(leftRows, leftSection), .deleteRows(rightRows, rightSection)):
+			return leftSection == rightSection && leftRows == rightRows
+		case let (.reloadRows(leftRows, leftSection), .reloadRows(rightRows, rightSection)):
+			return leftSection == rightSection && leftRows == rightRows
+		case let (.moveRow(leftSource, leftDestination, leftSection), .moveRow(rightSource, rightDestination, rightSection)):
+			return leftSection == rightSection && leftSource == rightSource && leftDestination == rightDestination
+		default:
+			return false
+		}
+	}
+}

--- a/Sources/Delta.swift
+++ b/Sources/Delta.swift
@@ -1,4 +1,6 @@
 import Foundation
+import ReactiveSwift
+import Result
 
 /// `Delta` represents an atomic batch of changes applied to a collection.
 public struct Delta<ChangeRepresentation: Collection> {
@@ -219,5 +221,23 @@ extension IndexingDelta where IndexPairs.Iterator.Element == (Snapshot.Index, Sn
 			return (Int(collections.0.distance(from: collections.0.startIndex, to: indices.0).toIntMax()),
 			        Int(collections.1.distance(from: collections.1.startIndex, to: indices.1).toIntMax()))
 		}
+	}
+}
+
+public protocol IndexingDeltaSection {
+	associatedtype Delta: IndexingDelta
+	associatedtype Metadata
+
+	var metadata: Property<Metadata> { get }
+	var deltas: SignalProducer<Delta, NoError> { get }
+}
+
+public struct DefaultSection<Delta: IndexingDelta>: IndexingDeltaSection {
+	public let metadata: Property<()>
+	public let deltas: SignalProducer<Delta, NoError>
+
+	public init(deltas: SignalProducer<Delta, NoError>) {
+		self.deltas = deltas
+		self.metadata = Property(value: ())
 	}
 }

--- a/Sources/Delta.swift
+++ b/Sources/Delta.swift
@@ -1,39 +1,223 @@
 import Foundation
 
-public struct Delta<Snapshot: Collection, ChangeRepresentation> {
-	public let previous: Snapshot
-	public let current: Snapshot
-
+/// `Delta` represents an atomic batch of changes applied to a collection.
+public struct Delta<ChangeRepresentation: Collection> {
 	public let inserts: ChangeRepresentation
 	public let deletes: ChangeRepresentation
-	public let updates: ChangeRepresentation
+
+	public init(inserts: ChangeRepresentation, deletes: ChangeRepresentation) {
+		self.inserts = inserts
+		self.deletes = deletes
+	}
+}
+
+extension Delta where ChangeRepresentation: ExpressibleByArrayLiteral {
+	public init(inserts: ChangeRepresentation = [], deletes: ChangeRepresentation = []) {
+		self.inserts = inserts
+		self.deletes = deletes
+	}
+}
+
+extension Delta where ChangeRepresentation: Equatable {
+	public static func ==(lhs: Delta<ChangeRepresentation>, rhs: Delta<ChangeRepresentation>) -> Bool {
+		return lhs.inserts == rhs.inserts &&
+			lhs.deletes == rhs.deletes
+	}
 }
 
 extension Delta: CustomDebugStringConvertible {
 	public var debugDescription: String {
-		return "previous: \(String(describing: previous)); current: \(String(describing: current)); inserts: \(String(describing: inserts)); deletes: \(String(describing: deletes)); updates: \(String(describing: updates))"
+		return "inserts: \(inserts); deletes: \(deletes)"
 	}
 }
 
-extension Delta where Snapshot.Iterator.Element: Equatable, ChangeRepresentation: Equatable {
+// FIXME: Swift 4 Conditional Conformance
+//
+// Remove the protocol after `CountableRange` is folded into `Range`.
+public protocol RangeProtocol {
+	associatedtype Bound
 
-	public static func ==(lhs: Delta<Snapshot, ChangeRepresentation>, rhs: Delta<Snapshot, ChangeRepresentation>) -> Bool {
+	var lowerBound: Bound { get }
+	var upperBound: Bound { get }
+}
 
-		guard lhs.inserts == rhs.inserts
-			&& lhs.deletes == rhs.deletes
-			else { return false }
+extension Range: RangeProtocol {}
+extension CountableRange: RangeProtocol {}
 
-		return lhs.previous == rhs.previous && lhs.current == rhs.current
+// FIXME: Swift collection model future enhancements
+//
+// This would be replaced by the `Segments` associated type of
+// `IndexingDelta.ChangeRepresentation`.
+//
+// https://bugs.swift.org/browse/SR-3633
+public protocol RangeRepresentableCollection: Collection {
+	// FIXME: Swift 4 Associated Type Constraints
+	//
+	// associatedtype RangeRepresentation: Collection where RangeRepresentation.Element == Range<Element>
+	associatedtype RangeRepresentation: Collection
+
+	// FIXME: Swift 4 Associated Type Constraints
+	//
+	// associatedtype Iterator where Iterator.Element: Comparable
+
+	var ranges: RangeRepresentation { get }
+}
+
+extension IndexSet: RangeRepresentableCollection {
+	public var ranges: RangeView {
+		return rangeView
+	}
+}
+
+/// `IndexingDelta` is an abstraction for describing an atomic batch of changes applied to
+/// a collection with a stable element order.
+///
+/// The protocol requires conforming types to guarantee a stable order of elements across
+/// deltas, such that consumers of the delta may safely derive integer offsets from the
+/// indices. In other words, given index *I* of delta *A* and index *J* of delta *B*
+/// referring to a certain position *P*, the derived offset of both index *I* and *J* must
+/// equal, provided that *P* has not been affected by any insertions or removals.
+///
+/// While the protocol supports `Collection` and `BidirectionalCollection`, it is expected
+/// to be most performant with the O(1) index manipulation guarantee of
+/// `RandomAccessCollection`.
+///
+/// Support of move operations is not mandatory. Source collections of may choose to
+/// represent it as a delete offset and an insert offset, if it is expected to be more
+/// performant, e.g. for `Collection` and `BidirectionalCollection`.
+public protocol IndexingDelta {
+	associatedtype Snapshot: Collection
+
+	// FIXME: Swift 4 Associated Type Constraints
+	//
+	// associatedtype ChangeRepresentation: Collection where ChangeRepresentation.Element == Snapshot.Index
+	associatedtype ChangeRepresentation: Collection
+
+	// FIXME: Swift 4 Associated Type Constraints
+	//
+	// associatedtype IndexPairs: Collection where IndexPairs.Element == (Snapshot.Index, Snapshot.Index)
+	associatedtype IndexPairs: Collection = EmptyCollection<(Snapshot.Index, Snapshot.Index)>
+
+	/// The collection prior to the changes.
+	var previous: Snapshot { get }
+
+	/// The collection after the changes.
+	var current: Snapshot { get }
+
+	/// The indices of insertions made to the collection. The indices should be based on
+	/// the order after deletions are applied.
+	var inserts: ChangeRepresentation { get }
+
+	/// The indices of deletions made to the collection. The indices should be based on
+	/// the original order, or in other words ignore all insertions.
+	var deletes: ChangeRepresentation { get }
+
+	/// The indices of updates made to the collection. The indices should be based on
+	/// the original order, or in other words ignore all insertions.
+	var updates: ChangeRepresentation { get }
+
+	/// The pairs of indices that represent moves made to the collection. The first
+	/// index is the source, and the second is the destination. The source index abides to
+	/// the same requirement as a delete, whereas the destination index abides to the same
+	/// requirement as an insert.
+	///
+	/// - note: This is an optional requirement. If a conforming type does not wish to
+	///         implement move tracking, it may emit any equivalent combination of
+	///         inserts, deletes and updates.
+	var moves: IndexPairs { get }
+
+	static func computeOffsets(for indices: ChangeRepresentation, in collection: Snapshot) -> IndexSet
+
+	static func computeOffsetPairs(from indexPairs: IndexPairs, in collections: (Snapshot, Snapshot)) -> [(Int, Int)]
+}
+
+extension IndexingDelta {
+	public var moves: EmptyCollection<(Snapshot.Index, Snapshot.Index)> {
+		return EmptyCollection()
+	}
+}
+
+extension IndexingDelta where Snapshot.Iterator.Element: Equatable, ChangeRepresentation: Equatable, IndexPairs.Iterator.Element == (Snapshot.Index, Snapshot.Index) {
+	public static func ==(lhs: Self, rhs: Self) -> Bool {
+		return lhs.previous == rhs.previous &&
+			lhs.current == rhs.current &&
+			lhs.inserts == rhs.inserts &&
+			lhs.deletes == rhs.deletes &&
+			lhs.updates == rhs.updates &&
+			lhs.moves == rhs.moves
+	}
+}
+
+/// `ArrayDelta` represents an atomic batch of changes applied to an array.
+public struct ArrayDelta<Snapshot: Collection>: IndexingDelta where Snapshot.Index == Int, Snapshot.IndexDistance.Stride: SignedInteger {
+	public typealias ChangeRepresentation = IndexSet
+
+	public let previous: Snapshot
+	public let current: Snapshot
+
+	public let inserts: IndexSet
+	public let deletes: IndexSet
+	public let updates: IndexSet
+	public let moves: [(Int, Int)]
+
+	public init(previous: Snapshot, current: Snapshot, inserts: IndexSet = [], deletes: IndexSet = [], updates: IndexSet = [], moves: [(Int, Int)] = []) {
+		self.previous = previous
+		self.current = current
+		self.inserts = inserts
+		self.deletes = deletes
+		self.updates = updates
+		self.moves = moves
+	}
+}
+
+extension ArrayDelta: CustomDebugStringConvertible {
+	public var debugDescription: String {
+		return "previous: \(previous.count) element(s); current: \(current.count) element(s); inserts: \(inserts); deletes: \(deletes); updates: \(updates)"
 	}
 }
 
 fileprivate extension Collection where Iterator.Element: Equatable {
-
 	fileprivate static func ==(lhs: Self, rhs: Self) -> Bool {
 		guard lhs.count == rhs.count else {
 			return false
 		}
 
 		return zip(lhs, rhs).first(where: !=) == nil
+	}
+}
+
+extension IndexingDelta where ChangeRepresentation.Iterator.Element: Comparable, Snapshot.Index == ChangeRepresentation.Iterator.Element, Snapshot.IndexDistance.Stride: SignedInteger {
+	public static func computeOffsets(for indices: ChangeRepresentation, in collection: Snapshot) -> IndexSet {
+		var iteratingIndex = collection.startIndex
+		var indexSet = IndexSet()
+		for index in indices {
+			let distance = collection.distance(from: iteratingIndex, to: index)
+			iteratingIndex = index
+			indexSet.insert(Int(distance.toIntMax()))
+		}
+		return indexSet
+	}
+}
+
+extension IndexingDelta where ChangeRepresentation.Iterator.Element: Comparable, ChangeRepresentation: RangeRepresentableCollection, ChangeRepresentation.RangeRepresentation.Iterator.Element: RangeProtocol, ChangeRepresentation.RangeRepresentation.Iterator.Element.Bound == ChangeRepresentation.Iterator.Element, Snapshot.Index == ChangeRepresentation.Iterator.Element, Snapshot.IndexDistance.Stride: SignedInteger {
+	public static func computeOffsets(for indices: ChangeRepresentation, in collection: Snapshot) -> IndexSet {
+		var indexSet = IndexSet()
+		indices.ranges
+			.map { range -> CountableRange<Int> in
+				let start = collection.distance(from: collection.startIndex, to: range.lowerBound)
+				let end = collection.distance(from: range.lowerBound, to: range.upperBound)
+				return Int(start.toIntMax()) ..< Int((start + end).toIntMax())
+			}
+			.forEach { indexSet.insert(integersIn: $0) }
+		return indexSet
+	}
+}
+
+extension IndexingDelta where IndexPairs.Iterator.Element == (Snapshot.Index, Snapshot.Index) {
+	public static func computeOffsetPairs(from indexPairs: IndexPairs, in collections: (Snapshot, Snapshot)) -> [(Int, Int)] {
+		return indexPairs.map { indices in
+			return (Int(collections.0.distance(from: collections.0.startIndex, to: indices.0).toIntMax()),
+			        Int(collections.1.distance(from: collections.1.startIndex, to: indices.1).toIntMax()))
+		}
 	}
 }

--- a/Sources/ReactiveArray.swift
+++ b/Sources/ReactiveArray.swift
@@ -253,3 +253,15 @@ private final class Storage<Elements> {
 		return returnValue
 	}
 }
+
+private let voidProperty = Property(value: ())
+
+extension ReactiveArray: IndexingDeltaSection {
+	public var deltas: SignalProducer<Delta, NoError> {
+		return producer
+	}
+
+	public var metadata: Property<()> {
+		return voidProperty
+	}
+}

--- a/Sources/ReactiveArray.swift
+++ b/Sources/ReactiveArray.swift
@@ -4,7 +4,7 @@ import Result
 
 public final class ReactiveArray<Element>: RandomAccessCollection {
 	public typealias Snapshot = ContiguousArray<Element>
-	public typealias Delta = ReactiveCollections.Delta<Snapshot, IndexSet>
+	public typealias Delta = ReactiveCollections.ArrayDelta<Snapshot>
 
 	fileprivate let storage: Storage<ContiguousArray<Element>>
 	fileprivate let observer: Observer<Delta, NoError>
@@ -15,9 +15,7 @@ public final class ReactiveArray<Element>: RandomAccessCollection {
 			storage.modify { elements in
 				let delta = Delta(previous: [],
 				                  current: elements,
-				                  inserts: IndexSet(integersIn: elements.indices),
-				                  deletes: [],
-				                  updates: [])
+				                  inserts: IndexSet(integersIn: elements.startIndex ..< elements.endIndex))
 				observer.send(value: delta)
 
 				if let strongSelf = self {

--- a/Tests/ReactiveCollectionsTests/DataSourceSpec.swift
+++ b/Tests/ReactiveCollectionsTests/DataSourceSpec.swift
@@ -1,0 +1,166 @@
+import Foundation
+import ReactiveSwift
+import ReactiveCollections
+import Quick
+import Nimble
+import Result
+
+private final class TestDataSource: DataSource<ReactiveArray<ReactiveArray<String>>.Delta> {
+	var latestEvents: [TestDataSource.Event] = []
+
+	override func update(_ action: ((TestDataSource.Event) -> Void) -> Void) {
+		latestEvents = []
+		action { self.latestEvents.append($0) }
+	}
+}
+
+class DataSourceSpec: QuickSpec {
+	override func spec() {
+		describe("DataSource") {
+			var dataSource: TestDataSource!
+			var items: ReactiveArray<ReactiveArray<String>>!
+
+			beforeEach {
+				items = ReactiveArray()
+				dataSource = TestDataSource(deltas: items.producer)
+			}
+
+			func setup(with itemCounts: [Int] = []) {
+				items.modify { items in
+					for count in itemCounts {
+						let strings = (0 ..< count).map(String.init)
+						items.append(ReactiveArray(strings))
+
+						let last = items.last.map { Array($0) }
+						expect(last) == strings
+						expect(last?.count) == count
+					}
+				}
+
+				expect(items.count) == itemCounts.count
+
+				_ = dataSource.start()
+				expect(dataSource.latestEvents) == (!itemCounts.isEmpty ? [.insertSections(IndexSet(integersIn: 0 ..< itemCounts.count))] : [])
+			}
+
+			it("should have no section initially") {
+				setup()
+
+				expect(dataSource.sectionCount) == 0
+			}
+
+			it("should have multiple sections initially") {
+				setup(with: [0, 1, 2, 3])
+
+				expect(dataSource.sectionCount) == 4
+				expect(dataSource.rowCount(section: 0)) == 0
+				expect(dataSource.rowCount(section: 1)) == 1
+				expect(dataSource.rowCount(section: 2)) == 2
+				expect(dataSource.rowCount(section: 3)) == 3
+			}
+
+			it("should replace a section") {
+				setup(with: [0, 2, 0])
+				expect(dataSource.sectionCount) == 3
+				expect(dataSource.rowCount(section: 1)) == 2
+
+				let strings = (10 ..< 15).map(String.init)
+				items.modify { $0[1] = ReactiveArray(strings) }
+
+				expect(dataSource.sectionCount) == 3
+				expect(dataSource.rowCount(section: 1)) == 5
+				expect((0 ..< 5).map { dataSource[1, $0] }) == strings
+			}
+
+			it("should remove a section") {
+				setup(with: [0, 2, 0])
+				expect(dataSource.sectionCount) == 3
+
+				_ = items.modify { $0.remove(at: 1) }
+				expect(dataSource.sectionCount) == 2
+				expect(dataSource.latestEvents) == [.deleteSections([1])]
+
+				_ = items.modify { $0.remove(at: 0) }
+				expect(dataSource.sectionCount) == 1
+				expect(dataSource.latestEvents) == [.deleteSections([0])]
+
+				_ = items.modify { $0.remove(at: 0) }
+				expect(dataSource.sectionCount) == 0
+				expect(dataSource.latestEvents) == [.deleteSections([0])]
+			}
+
+			it("should remove all sections as the outer collection is emptied") {
+				setup(with: [3, 4])
+				expect(dataSource.rowCount(section: 0)) == 3
+				expect(dataSource.rowCount(section: 1)) == 4
+
+				items.modify { $0.removeAll() }
+				expect(dataSource.sectionCount) == 0
+				expect(dataSource.latestEvents) == [.deleteSections([0, 1])]
+			}
+
+			it("should insert rows when the array has new items") {
+				setup(with: [0])
+
+				let subitems = items[0]
+				for i in 0 ..< 10 {
+					subitems.modify { $0.append("\(i)") }
+					expect(dataSource.rowCount(section: 0)) == i + 1
+					expect(dataSource[0, i]) == "\(i)"
+				}
+			}
+
+			it("should support backward traversal") {
+				setup(with: [16])
+				expect(dataSource.rowCount(section: 0)) == 16
+
+				for i in (0 ..< 16).reversed() {
+					expect(dataSource[0, i]) == "\(i)"
+				}
+			}
+
+			it("should support random traversal") {
+				setup(with: [128])
+				expect(dataSource.rowCount(section: 0)) == 128
+
+				let indices = Array(shuffling: 0 ..< 128)
+
+				for i in indices {
+					expect(dataSource[0, i]) == "\(i)"
+				}
+			}
+
+			it("should remove a previously inserted item") {
+				setup(with: [0])
+
+				let subitems = items[0]
+				subitems.modify { $0.append(contentsOf: ["1", "2"]) }
+				expect(dataSource.rowCount(section: 0)) == 2
+				expect(dataSource[0, 0]) == "1"
+				expect(dataSource[0, 1]) == "2"
+
+				_ = subitems.modify { $0.remove(at: 1) }
+				expect(dataSource.rowCount(section: 0)) == 1
+				expect(dataSource[0, 0]) == "1"
+			}
+
+			// TODO: Add move operation tests.
+			//
+			// `ReactiveArray` does not support move operations yet.
+		}
+	}
+}
+
+extension Array {
+	fileprivate init<C: Collection>(shuffling elements: C) where C.Iterator.Element == Element {
+		self.init(elements)
+
+		for i in startIndex ..< endIndex {
+			let target = Int(arc4random() >> 1) % endIndex
+			
+			if target != i {
+				swap(&self[i], &self[target])
+			}
+		}
+	}
+}

--- a/Tests/ReactiveCollectionsTests/Delta+NimbleMatcher.swift
+++ b/Tests/ReactiveCollectionsTests/Delta+NimbleMatcher.swift
@@ -14,36 +14,53 @@ internal func ==<T: Equatable, C: Collection>(_ array: Expectation<ReactiveArray
 	})
 }
 
-internal func ==<Snapshot, ChangeRepresentation>(
-	left: Expectation<Delta<Snapshot, ChangeRepresentation>>,
-	right: Delta<Snapshot, ChangeRepresentation>
-) where Snapshot.Iterator.Element: Equatable, ChangeRepresentation: Equatable {
+internal func ==<ChangeRepresentation>(
+	left: Expectation<Delta<ChangeRepresentation>>,
+	right: Delta<ChangeRepresentation>
+) where ChangeRepresentation: Equatable {
 	return left.to(NonNilMatcherFunc { expression, failureMessage in
 		let value = try expression.evaluate()!
 		if value == right {
 			return true
 		}
 
-		failureMessage.expected = "expected \(right.debugDescription)"
+		failureMessage.expected = "expected \(String(reflecting: right))"
 		failureMessage.to = ""
-		failureMessage.actualValue = value.debugDescription
+		failureMessage.actualValue = String(reflecting: value)
 		return false
 	})
 }
 
-internal func ==<Snapshot, ChangeRepresentation>(
-	left: Expectation<[Delta<Snapshot, ChangeRepresentation>]>,
-	right: [Delta<Snapshot, ChangeRepresentation>]
-) where Snapshot.Iterator.Element: Equatable, ChangeRepresentation: Equatable {
+internal func ==<Delta: IndexingDelta>(
+	left: Expectation<Delta>,
+	right: Delta
+) where Delta.Snapshot.Iterator.Element: Equatable, Delta.ChangeRepresentation: Equatable, Delta.IndexPairs.Iterator.Element == (Delta.Snapshot.Index, Delta.Snapshot.Index) {
+	return left.to(NonNilMatcherFunc { expression, failureMessage in
+		let value = try expression.evaluate()!
+		if value == right {
+			return true
+		}
+
+		failureMessage.expected = "expected \(String(reflecting: right))"
+		failureMessage.to = ""
+		failureMessage.actualValue = String(reflecting: value)
+		return false
+	})
+}
+
+internal func ==<Delta: IndexingDelta>(
+	left: Expectation<[Delta]>,
+	right: [Delta]
+) where Delta.Snapshot.Iterator.Element: Equatable, Delta.ChangeRepresentation: Equatable, Delta.IndexPairs.Iterator.Element == (Delta.Snapshot.Index, Delta.Snapshot.Index) {
 	return left.to(NonNilMatcherFunc { expression, failureMessage in
 		let value = try expression.evaluate()!
 		if value.elementsEqual(right, by: ==) {
 			return true
 		}
 
-		failureMessage.expected = "expected \(right.debugDescription)"
+		failureMessage.expected = "expected \(String(reflecting: right))"
 		failureMessage.to = ""
-		failureMessage.actualValue = value.debugDescription
+		failureMessage.actualValue = String(reflecting: value)
 		return false
 	})
 }

--- a/Tests/ReactiveCollectionsTests/ReactiveArraySpec.swift
+++ b/Tests/ReactiveCollectionsTests/ReactiveArraySpec.swift
@@ -89,7 +89,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0[0] = 3 }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [3, 2, 3],
 						inserts: [],
@@ -115,7 +115,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.replaceSubrange(1...2, with: [1, 1]) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 1, 1],
 						inserts: [],
@@ -130,7 +130,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.replaceSubrange(0...1, with: [0, 0, 0]) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 1, 1],
 						current: [0, 0, 0, 1],
 						inserts: IndexSet(integer: 2),
@@ -145,7 +145,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.replaceSubrange(0...0, with: [1]) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [0, 0, 0, 1],
 						current: [1, 0, 0, 1],
 						inserts: [],
@@ -160,7 +160,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.replaceSubrange(array.indices, with: Array(0...5)) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 0, 0, 1],
 						current: [0, 1, 2, 3, 4, 5],
 						inserts: IndexSet(4...5),
@@ -184,7 +184,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.append(4) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2, 3, 4],
 						inserts: IndexSet(integer: 3),
@@ -208,7 +208,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.append(contentsOf: [4, 5, 6]) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2, 3, 4, 5, 6],
 						inserts: IndexSet(3..<6),
@@ -232,7 +232,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.insert(4, at: array.endIndex) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2, 3, 4],
 						inserts: IndexSet(integer: 3),
@@ -247,7 +247,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.insert(0, at: 0) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3, 4],
 						current: [0, 1, 2, 3, 4],
 						inserts: IndexSet(integer: 0),
@@ -271,7 +271,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.insert(contentsOf: [4, 5, 6], at: 0) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [4, 5, 6, 1, 2, 3],
 						inserts: IndexSet(0..<3),
@@ -295,7 +295,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeAll() }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [],
 						inserts: [],
@@ -319,7 +319,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeAll(keepingCapacity: true) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [],
 						inserts: [],
@@ -343,7 +343,7 @@ class ReactiveArraySpec: QuickSpec {
 				expect(array.modify { $0.removeFirst() }) == 1
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [2, 3],
 						inserts: [],
@@ -367,7 +367,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeFirst(2) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [3],
 						inserts: [],
@@ -391,7 +391,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeFirst(3) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [],
 						inserts: [],
@@ -415,7 +415,7 @@ class ReactiveArraySpec: QuickSpec {
 				expect(array.modify { $0.removeLast() }) == 3
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2],
 						inserts: [],
@@ -439,7 +439,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeLast(2) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1],
 						inserts: [],
@@ -463,7 +463,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeLast(3) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [],
 						inserts: [],
@@ -487,7 +487,7 @@ class ReactiveArraySpec: QuickSpec {
 				expect(array.modify { $0.remove(at: 1) }) == 2
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 3],
 						inserts: [],
@@ -511,7 +511,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeSubrange(1...2) }
 				
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1],
 						inserts: [],
@@ -567,7 +567,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == [8, 9, 0]
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: [8, 9, 0],
 					                             inserts: IndexSet(0 ..< 3),
 					                             deletes: IndexSet(0 ..< 3),
@@ -581,7 +581,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == [1, 2, 3]
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: [1, 2, 3],
 					                             inserts: [],
 					                             deletes: [],
@@ -595,7 +595,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == [1, 100, 2]
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: [1, 100, 2],
 					                             inserts: IndexSet(integer: 1),
 					                             deletes: IndexSet(integer: 2),
@@ -609,7 +609,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == [1, 100, 2, 200]
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: [1, 100, 2, 200],
 					                             inserts: IndexSet(integer: 1),
 					                             deletes: [],
@@ -627,7 +627,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == sorted
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: sorted,
 					                             inserts: IndexSet(integersIn: 3 ..< 11),
 					                             deletes: [],
@@ -646,7 +646,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == sorted
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: sorted,
 					                             inserts: IndexSet(integersIn: 0 ..< 11),
 					                             deletes: IndexSet(integersIn: 0 ..< 3),
@@ -668,21 +668,21 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeAll() }
 
 				let expectedChanges: [Change<Int>] = [
-					Delta(
+					ArrayDelta(
 						previous: [],
 						current: [1, 2, 3],
 						inserts: IndexSet(0..<3),
 						deletes: [],
 						updates: []
 					),
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2, 3, 4],
 						inserts: IndexSet(integer: 3),
 						deletes: [],
 						updates: []
 					),
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3, 4],
 						current: [],
 						inserts: [],
@@ -708,14 +708,14 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeAll() }
 
 				let expectedChanges: [Change<Int>] = [
-					Delta(
+					ArrayDelta(
 						previous: [],
 						current: [1, 2, 3, 4],
 						inserts: IndexSet(0..<4),
 						deletes: [],
 						updates: []
 					),
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3, 4],
 						current: [],
 						inserts: [],

--- a/Tests/UIKitExtensionsTests/UITableViewSpec.swift
+++ b/Tests/UIKitExtensionsTests/UITableViewSpec.swift
@@ -1,0 +1,118 @@
+import UIKit
+import ReactiveSwift
+import ReactiveCollections
+import Quick
+import Nimble
+
+class UITableViewSpec: QuickSpec {
+	override func spec() {
+		describe("UITableView") {
+			var window: UIWindow!
+			var tableView: UITableView!
+			var items: ReactiveArray<String>!
+
+			beforeEach {
+				window = UIWindow()
+
+				tableView = UITableView(frame: CGRect(x: 0, y: 0, width: 100, height: 800),
+				                        style: .plain)
+				tableView.register(UITableViewCell.self, forCellReuseIdentifier: "ItemCell")
+				window.addSubview(tableView)
+
+				items = ReactiveArray()
+			}
+
+			func setup(with itemCount: Int = 0) {
+				items.modify { $0.append(contentsOf: (0 ..< itemCount).lazy.map { "\($0)" }) }
+				expect(items.count) == itemCount
+
+				tableView.reactive.collection <~ items.producer.map { item, cellFactory in
+					let cell = cellFactory("ItemCell")
+					cell.textLabel?.text = item
+					return cell
+				}
+			}
+
+			it("should have one section only") {
+				setup()
+				expect(tableView.numberOfSections) == 1
+			}
+
+			it("should have acknowledged existing rows") {
+				setup(with: 16)
+				expect(tableView.numberOfRows(inSection: 0)) == 16
+			}
+
+			it("should remove all rows as the array is emptied") {
+				setup(with: 16)
+				expect(tableView.numberOfRows(inSection: 0)) == 16
+
+				items.modify { $0.removeAll() }
+				expect(tableView.numberOfRows(inSection: 0)) == 0
+			}
+
+			it("should insert rows when the array has new items") {
+				setup()
+
+				for i in 0 ..< 10 {
+					items.modify { $0.append("\(i)") }
+					expect(tableView.numberOfRows(inSection: 0)) == i + 1
+					expect(tableView.cellForRow(at: IndexPath(row: i, section: 0))?.textLabel?.text) == "\(i)"
+				}
+			}
+
+			it("should support backward traversal") {
+				setup(with: 16)
+				expect(tableView.numberOfRows(inSection: 0)) == 16
+
+				for i in (0 ..< 16).reversed() {
+					expect(tableView.cellForRow(at: IndexPath(row: i, section: 0))?.textLabel?.text) == "\(i)"
+				}
+			}
+
+			it("should support random traversal") {
+				setup(with: 128)
+				expect(tableView.numberOfRows(inSection: 0)) == 128
+
+				let indices = Array(shuffling: 0 ..< 128)
+
+				for i in indices {
+					let indexPath = IndexPath(row: i, section: 0)
+					tableView.scrollToRow(at: indexPath, at: .top, animated: false)
+					expect(tableView.cellForRow(at: indexPath)?.textLabel?.text) == "\(i)"
+				}
+			}
+
+			it("should remove a previously inserted item") {
+				setup()
+
+				items.modify { $0.append(contentsOf: ["1", "2"]) }
+				expect(tableView.numberOfRows(inSection: 0)) == 2
+				expect(tableView.cellForRow(at: IndexPath(row: 0, section: 0))?.textLabel?.text) == "1"
+				expect(tableView.cellForRow(at: IndexPath(row: 1, section: 0))?.textLabel?.text) == "2"
+
+				_ = items.modify { $0.remove(at: 1) }
+				expect(tableView.numberOfRows(inSection: 0)) == 1
+				expect(tableView.cellForRow(at: IndexPath(row: 0, section: 0))?.textLabel?.text) == "1"
+			}
+
+			// TODO: Add move operation tests.
+			// 
+			// `ReactiveArray` does not support move operations yet.
+		}
+	}
+}
+
+extension Array {
+	fileprivate init<C: Collection>(shuffling elements: C) where C.Iterator.Element == Element {
+		self.init(elements)
+
+		for i in startIndex ..< endIndex {
+			let target = Int(arc4random() >> 1) % endIndex
+
+			if target != i {
+				swap(&self[i], &self[target])
+			}
+		}
+	}
+}

--- a/UIKit/UITableView.swift
+++ b/UIKit/UITableView.swift
@@ -1,0 +1,142 @@
+import UIKit
+import ReactiveCocoa
+import ReactiveSwift
+import Result
+
+extension Reactive where Base: UITableView {
+	public var collection: BindingTarget<(UITableView) -> Void> {
+		return BindingTarget(lifetime: lifetime) { [weak base] in
+			if let base = base {
+				$0(base)
+			}
+		}
+	}
+}
+
+// FIXME: Swift 4 Associated Type Constraints
+//
+// extension SignalProducer
+// where Value: IndexingDelta, Error == NoError {
+extension SignalProducer
+where Value: IndexingDelta,
+      Value.IndexPairs.Iterator.Element == (Value.Snapshot.Index, Value.Snapshot.Index),
+      Value.Snapshot.Index == Value.ChangeRepresentation.Iterator.Element,
+      Value.Snapshot.IndexDistance.Stride: SignedInteger,
+      Error == NoError {
+	public func map(
+		_ transform: @escaping (Value.Snapshot.Iterator.Element, (String) -> UITableViewCell) -> UITableViewCell
+	) -> SignalProducer<(UITableView) -> Void, NoError> {
+		return map(transform, bidirectional: false)
+	}
+
+	fileprivate func map(
+		_ transform: @escaping (Value.Snapshot.Iterator.Element, (String) -> UITableViewCell) -> UITableViewCell,
+		bidirectional: Bool
+	) -> SignalProducer<(UITableView) -> Void, NoError> {
+		return SignalProducer<(UITableView) -> Void, NoError> { observer, disposable in
+			observer.send(value: { tableView in
+				let array: ReactiveArray<DefaultSection<Value>> = [DefaultSection(deltas: self)]
+				let dataSource = TableViewDataSource(deltas: array.producer,
+				                                     tableView: tableView,
+				                                     transform: transform,
+				                                     canTraverseBidirectionally: bidirectional)
+
+				tableView.dataSource = dataSource
+				disposable += dataSource.start()
+				disposable += { _ = array }
+			})
+		}
+	}
+}
+
+// FIXME: Swift 4 Associated Type Constraints
+//
+// extension SignalProducer
+// where Value: IndexingDelta, Value.Snapshot: BidirectionalCollection, Error == NoError {
+extension SignalProducer
+where Value: IndexingDelta,
+      Value.Snapshot: BidirectionalCollection,
+      Value.IndexPairs.Iterator.Element == (Value.Snapshot.Index, Value.Snapshot.Index),
+      Value.Snapshot.Index == Value.ChangeRepresentation.Iterator.Element,
+      Value.Snapshot.IndexDistance.Stride: SignedInteger,
+      Error == NoError {
+	public func map(
+		_ transform: @escaping (Value.Snapshot.Iterator.Element, (String) -> UITableViewCell) -> UITableViewCell
+	) -> SignalProducer<(UITableView) -> Void, NoError> {
+		return map(transform, bidirectional: true)
+	}
+}
+
+// FIXME: Swift 4 Associated Type Constraints
+//
+// private final class ReactiveUITableViewDataSource<Delta>: NSObject, UITableViewDataSource
+// where Delta: IndexingDelta, Delta.Snapshot.Element: IndexingDeltaSection
+private final class TableViewDataSource<Delta: IndexingDelta>: DataSource<Delta>, UITableViewDataSource
+where Delta.IndexPairs.Iterator.Element == (Delta.Snapshot.Index,Delta.Snapshot.Index),
+      Delta.Snapshot.Index == Delta.ChangeRepresentation.Iterator.Element,
+      Delta.Snapshot.IndexDistance.Stride: SignedInteger,
+      Delta.Snapshot.Iterator.Element: IndexingDeltaSection,
+      Delta.Snapshot.Iterator.Element.Delta: IndexingDelta,
+      Delta.Snapshot.Iterator.Element.Delta.IndexPairs.Iterator.Element == (Delta.Snapshot.Iterator.Element.Delta.Snapshot.Index, Delta.Snapshot.Iterator.Element.Delta.Snapshot.Index),
+      Delta.Snapshot.Iterator.Element.Delta.Snapshot.Index == Delta.Snapshot.Iterator.Element.Delta.ChangeRepresentation.Iterator.Element,
+      Delta.Snapshot.Iterator.Element.Delta.Snapshot.IndexDistance.Stride: SignedInteger {
+	typealias Transform = (Delta.Snapshot.Iterator.Element.Delta.Snapshot.Iterator.Element, (String) -> UITableViewCell) -> UITableViewCell
+
+	private let transform: Transform
+	private weak var tableView: UITableView?
+
+	init(deltas: SignalProducer<Delta, NoError>, tableView: UITableView, transform: @escaping Transform, canTraverseBidirectionally: Bool) {
+		self.transform = transform
+		self.tableView = tableView
+		super.init(deltas: deltas, canInnerTraverseBidirectionally: canTraverseBidirectionally)
+	}
+
+	override func update(_ action: ((Event) -> Void) -> Void) {
+		guard let t = tableView else { return }
+
+		action { event in
+			switch event {
+			case .reloadAll:
+				t.reloadData()
+
+			case let .insertSections(indices):
+				t.insertSections(indices, with: .automatic)
+
+			case let .deleteSections(indices):
+				t.deleteSections(indices, with: .automatic)
+
+			case let .reloadSections(indices):
+				t.reloadSections(indices, with: .automatic)
+
+			case let .moveSection(source, destination):
+				t.moveSection(source, toSection: destination)
+
+			case let .insertRows(indices, section):
+				t.insertRows(at: indices.map { IndexPath(row: $0, section: section) }, with: .automatic)
+
+			case let .deleteRows(indices, section):
+				t.deleteRows(at: indices.map { IndexPath(row: $0, section: section) }, with: .automatic)
+
+			case let .reloadRows(indices, section):
+				t.reloadRows(at: indices.map { IndexPath(row: $0, section: section) }, with: .automatic)
+
+			case let .moveRow(source, destination, section):
+				t.moveRow(at: IndexPath(row: source, section: section), to: IndexPath(row: destination, section: section))
+			}
+		}
+	}
+
+	func numberOfSections(in tableView: UITableView) -> Int {
+		return sectionCount
+	}
+
+	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+		return transform(self[indexPath.section, indexPath.row]) { reuseIdentifier in
+			return tableView.dequeueReusableCell(withIdentifier: reuseIdentifier, for: indexPath)
+		}
+	}
+
+	func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+		return rowCount(section: section)
+	}
+}


### PR DESCRIPTION
Dependency: #25.

The API blueprint:

```swift
tableView.reactive.collection(
	.animation(insert: .automatic, delete: .automatic, reload: .automatic),
	.editable(editPredicate, commitAction),
	.movable(movePredicate, moveAction)
) <~ items.producer.map { item, cellFactory in
	let cell = cellFactory("ItemCell")
	cell.textLabel?.text = item
	return cell
}
```

The design attempts to present the entirety of table view sourcing as simple as mapping a collection to cells with the feel of FRP. Hopefully it should be applicable to other collection views (probably except NSTableView).

Instead of binding from a collection, its delta producer is used instead. This should be sufficiently flexible for layering and interoperating with, say, collection diffing signal/property operators.

Note: Support of sections, editable rows and moveable rows are not part of the PR.

### To-do

- [x] 1D collection delta binding.
- [x] Test coverage for 1D collection delta binding.
- [x] 2D collection delta binding.
- [ ] Test coverage for 2D collection delta binding.
- [ ] Reevaluate the use of protocols and constraints.
- [ ] Configurations (e.g. animations).
