### PR TITLE
Introduce `ArrayDelta` and the `IndexingDelta` protocol.

### DIFF
--- a/Sources/Delta.swift
+++ b/Sources/Delta.swift
@@ -172,7 +172,7 @@ public struct ArrayDelta<Snapshot: Collection>: IndexingDelta where Snapshot.Ind
 
 extension ArrayDelta: CustomDebugStringConvertible {
 	public var debugDescription: String {
-		return "previous: \(previous.count) element(s); current: \(current.count) element(s); inserts: \(inserts); deletes: \(deletes); updates: \(updates)"
+		return "previous: \(previous.count) element(s)\n>> \(previous)\ncurrent: \(current.count) element(s)\n>> \(current)\ninserts: \(inserts.count)\n>> \(Array(inserts))\ndeletes: \(deletes.count)\n>> \(Array(deletes))\nupdates: \(updates.count)\n>> \(Array(updates))\nmoves: \(moves.count)\n>> \(Array(moves))"
 	}
 }
 

--- a/Sources/Delta.swift
+++ b/Sources/Delta.swift
@@ -1,39 +1,223 @@
 import Foundation
 
-public struct Delta<Snapshot: Collection, ChangeRepresentation> {
-	public let previous: Snapshot
-	public let current: Snapshot
-
+/// `Delta` represents an atomic batch of changes applied to a collection.
+public struct Delta<ChangeRepresentation: Collection> {
 	public let inserts: ChangeRepresentation
 	public let deletes: ChangeRepresentation
-	public let updates: ChangeRepresentation
+
+	public init(inserts: ChangeRepresentation, deletes: ChangeRepresentation) {
+		self.inserts = inserts
+		self.deletes = deletes
+	}
+}
+
+extension Delta where ChangeRepresentation: ExpressibleByArrayLiteral {
+	public init(inserts: ChangeRepresentation = [], deletes: ChangeRepresentation = []) {
+		self.inserts = inserts
+		self.deletes = deletes
+	}
+}
+
+extension Delta where ChangeRepresentation: Equatable {
+	public static func ==(lhs: Delta<ChangeRepresentation>, rhs: Delta<ChangeRepresentation>) -> Bool {
+		return lhs.inserts == rhs.inserts &&
+			lhs.deletes == rhs.deletes
+	}
 }
 
 extension Delta: CustomDebugStringConvertible {
 	public var debugDescription: String {
-		return "previous: \(String(describing: previous)); current: \(String(describing: current)); inserts: \(String(describing: inserts)); deletes: \(String(describing: deletes)); updates: \(String(describing: updates))"
+		return "inserts: \(inserts); deletes: \(deletes)"
 	}
 }
 
-extension Delta where Snapshot.Iterator.Element: Equatable, ChangeRepresentation: Equatable {
+// FIXME: Swift 4 Conditional Conformance
+//
+// Remove the protocol after `CountableRange` is folded into `Range`.
+public protocol RangeProtocol {
+	associatedtype Bound
 
-	public static func ==(lhs: Delta<Snapshot, ChangeRepresentation>, rhs: Delta<Snapshot, ChangeRepresentation>) -> Bool {
+	var lowerBound: Bound { get }
+	var upperBound: Bound { get }
+}
 
-		guard lhs.inserts == rhs.inserts
-			&& lhs.deletes == rhs.deletes
-			else { return false }
+extension Range: RangeProtocol {}
+extension CountableRange: RangeProtocol {}
 
-		return lhs.previous == rhs.previous && lhs.current == rhs.current
+// FIXME: Swift collection model future enhancements
+//
+// This would be replaced by the `Segments` associated type of
+// `IndexingDelta.ChangeRepresentation`.
+//
+// https://bugs.swift.org/browse/SR-3633
+public protocol RangeRepresentableCollection: Collection {
+	// FIXME: Swift 4 Associated Type Constraints
+	//
+	// associatedtype RangeRepresentation: Collection where RangeRepresentation.Element == Range<Element>
+	associatedtype RangeRepresentation: Collection
+
+	// FIXME: Swift 4 Associated Type Constraints
+	//
+	// associatedtype Iterator where Iterator.Element: Comparable
+
+	var ranges: RangeRepresentation { get }
+}
+
+extension IndexSet: RangeRepresentableCollection {
+	public var ranges: RangeView {
+		return rangeView
+	}
+}
+
+/// `IndexingDelta` is an abstraction for describing an atomic batch of changes applied to
+/// a collection with a stable element order.
+///
+/// The protocol requires conforming types to guarantee a stable order of elements across
+/// deltas, such that consumers of the delta may safely derive integer offsets from the
+/// indices. In other words, given index *I* of delta *A* and index *J* of delta *B*
+/// referring to a certain position *P*, the derived offset of both index *I* and *J* must
+/// equal, provided that *P* has not been affected by any insertions or removals.
+///
+/// While the protocol supports `Collection` and `BidirectionalCollection`, it is expected
+/// to be most performant with the O(1) index manipulation guarantee of
+/// `RandomAccessCollection`.
+///
+/// Support of move operations is not mandatory. Source collections of may choose to
+/// represent it as a delete offset and an insert offset, if it is expected to be more
+/// performant, e.g. for `Collection` and `BidirectionalCollection`.
+public protocol IndexingDelta {
+	associatedtype Snapshot: Collection
+
+	// FIXME: Swift 4 Associated Type Constraints
+	//
+	// associatedtype ChangeRepresentation: Collection where ChangeRepresentation.Element == Snapshot.Index
+	associatedtype ChangeRepresentation: Collection
+
+	// FIXME: Swift 4 Associated Type Constraints
+	//
+	// associatedtype IndexPairs: Collection where IndexPairs.Element == (Snapshot.Index, Snapshot.Index)
+	associatedtype IndexPairs: Collection = EmptyCollection<(Snapshot.Index, Snapshot.Index)>
+
+	/// The collection prior to the changes.
+	var previous: Snapshot { get }
+
+	/// The collection after the changes.
+	var current: Snapshot { get }
+
+	/// The indices of insertions made to the collection. The indices should be based on
+	/// the order after deletions are applied.
+	var inserts: ChangeRepresentation { get }
+
+	/// The indices of deletions made to the collection. The indices should be based on
+	/// the original order, or in other words ignore all insertions.
+	var deletes: ChangeRepresentation { get }
+
+	/// The indices of updates made to the collection. The indices should be based on
+	/// the original order, or in other words ignore all insertions.
+	var updates: ChangeRepresentation { get }
+
+	/// The pairs of indices that represent moves made to the collection. The first
+	/// index is the source, and the second is the destination. The source index abides to
+	/// the same requirement as a delete, whereas the destination index abides to the same
+	/// requirement as an insert.
+	///
+	/// - note: This is an optional requirement. If a conforming type does not wish to
+	///         implement move tracking, it may emit any equivalent combination of
+	///         inserts, deletes and updates.
+	var moves: IndexPairs { get }
+
+	static func computeOffsets(for indices: ChangeRepresentation, in collection: Snapshot) -> IndexSet
+
+	static func computeOffsetPairs(from indexPairs: IndexPairs, in collections: (Snapshot, Snapshot)) -> [(Int, Int)]
+}
+
+extension IndexingDelta {
+	public var moves: EmptyCollection<(Snapshot.Index, Snapshot.Index)> {
+		return EmptyCollection()
+	}
+}
+
+extension IndexingDelta where Snapshot.Iterator.Element: Equatable, ChangeRepresentation: Equatable, IndexPairs.Iterator.Element == (Snapshot.Index, Snapshot.Index) {
+	public static func ==(lhs: Self, rhs: Self) -> Bool {
+		return lhs.previous == rhs.previous &&
+			lhs.current == rhs.current &&
+			lhs.inserts == rhs.inserts &&
+			lhs.deletes == rhs.deletes &&
+			lhs.updates == rhs.updates &&
+			lhs.moves == rhs.moves
+	}
+}
+
+/// `ArrayDelta` represents an atomic batch of changes applied to an array.
+public struct ArrayDelta<Snapshot: Collection>: IndexingDelta where Snapshot.Index == Int, Snapshot.IndexDistance.Stride: SignedInteger {
+	public typealias ChangeRepresentation = IndexSet
+
+	public let previous: Snapshot
+	public let current: Snapshot
+
+	public let inserts: IndexSet
+	public let deletes: IndexSet
+	public let updates: IndexSet
+	public let moves: [(Int, Int)]
+
+	public init(previous: Snapshot, current: Snapshot, inserts: IndexSet = [], deletes: IndexSet = [], updates: IndexSet = [], moves: [(Int, Int)] = []) {
+		self.previous = previous
+		self.current = current
+		self.inserts = inserts
+		self.deletes = deletes
+		self.updates = updates
+		self.moves = moves
+	}
+}
+
+extension ArrayDelta: CustomDebugStringConvertible {
+	public var debugDescription: String {
+		return "previous: \(previous.count) element(s); current: \(current.count) element(s); inserts: \(inserts); deletes: \(deletes); updates: \(updates)"
 	}
 }
 
 fileprivate extension Collection where Iterator.Element: Equatable {
-
 	fileprivate static func ==(lhs: Self, rhs: Self) -> Bool {
 		guard lhs.count == rhs.count else {
 			return false
 		}
 
 		return zip(lhs, rhs).first(where: !=) == nil
+	}
+}
+
+extension IndexingDelta where ChangeRepresentation.Iterator.Element: Comparable, Snapshot.Index == ChangeRepresentation.Iterator.Element, Snapshot.IndexDistance.Stride: SignedInteger {
+	public static func computeOffsets(for indices: ChangeRepresentation, in collection: Snapshot) -> IndexSet {
+		var iteratingIndex = collection.startIndex
+		var indexSet = IndexSet()
+		for index in indices {
+			let distance = collection.distance(from: iteratingIndex, to: index)
+			iteratingIndex = index
+			indexSet.insert(Int(distance.toIntMax()))
+		}
+		return indexSet
+	}
+}
+
+extension IndexingDelta where ChangeRepresentation.Iterator.Element: Comparable, ChangeRepresentation: RangeRepresentableCollection, ChangeRepresentation.RangeRepresentation.Iterator.Element: RangeProtocol, ChangeRepresentation.RangeRepresentation.Iterator.Element.Bound == ChangeRepresentation.Iterator.Element, Snapshot.Index == ChangeRepresentation.Iterator.Element, Snapshot.IndexDistance.Stride: SignedInteger {
+	public static func computeOffsets(for indices: ChangeRepresentation, in collection: Snapshot) -> IndexSet {
+		var indexSet = IndexSet()
+		indices.ranges
+			.map { range -> CountableRange<Int> in
+				let start = collection.distance(from: collection.startIndex, to: range.lowerBound)
+				let end = collection.distance(from: range.lowerBound, to: range.upperBound)
+				return Int(start.toIntMax()) ..< Int((start + end).toIntMax())
+			}
+			.forEach { indexSet.insert(integersIn: $0) }
+		return indexSet
+	}
+}
+
+extension IndexingDelta where IndexPairs.Iterator.Element == (Snapshot.Index, Snapshot.Index) {
+	public static func computeOffsetPairs(from indexPairs: IndexPairs, in collections: (Snapshot, Snapshot)) -> [(Int, Int)] {
+		return indexPairs.map { indices in
+			return (Int(collections.0.distance(from: collections.0.startIndex, to: indices.0).toIntMax()),
+			        Int(collections.1.distance(from: collections.1.startIndex, to: indices.1).toIntMax()))
+		}
 	}
 }

--- a/Sources/ReactiveArray.swift
+++ b/Sources/ReactiveArray.swift
@@ -4,7 +4,7 @@ import Result
 
 public final class ReactiveArray<Element>: RandomAccessCollection {
 	public typealias Snapshot = ContiguousArray<Element>
-	public typealias Delta = ReactiveCollections.Delta<Snapshot, IndexSet>
+	public typealias Delta = ReactiveCollections.ArrayDelta<Snapshot>
 
 	fileprivate let storage: Storage<ContiguousArray<Element>>
 	fileprivate let observer: Observer<Delta, NoError>
@@ -15,9 +15,7 @@ public final class ReactiveArray<Element>: RandomAccessCollection {
 			storage.modify { elements in
 				let delta = Delta(previous: [],
 				                  current: elements,
-				                  inserts: IndexSet(integersIn: elements.indices),
-				                  deletes: [],
-				                  updates: [])
+				                  inserts: IndexSet(integersIn: elements.startIndex ..< elements.endIndex))
 				observer.send(value: delta)
 
 				if let strongSelf = self {

--- a/Tests/ReactiveCollectionsTests/Delta+NimbleMatcher.swift
+++ b/Tests/ReactiveCollectionsTests/Delta+NimbleMatcher.swift
@@ -14,36 +14,53 @@ internal func ==<T: Equatable, C: Collection>(_ array: Expectation<ReactiveArray
 	})
 }
 
-internal func ==<Snapshot, ChangeRepresentation>(
-	left: Expectation<Delta<Snapshot, ChangeRepresentation>>,
-	right: Delta<Snapshot, ChangeRepresentation>
-) where Snapshot.Iterator.Element: Equatable, ChangeRepresentation: Equatable {
+internal func ==<ChangeRepresentation>(
+	left: Expectation<Delta<ChangeRepresentation>>,
+	right: Delta<ChangeRepresentation>
+) where ChangeRepresentation: Equatable {
 	return left.to(NonNilMatcherFunc { expression, failureMessage in
 		let value = try expression.evaluate()!
 		if value == right {
 			return true
 		}
 
-		failureMessage.expected = "expected \(right.debugDescription)"
+		failureMessage.expected = "expected \(String(reflecting: right))"
 		failureMessage.to = ""
-		failureMessage.actualValue = value.debugDescription
+		failureMessage.actualValue = String(reflecting: value)
 		return false
 	})
 }
 
-internal func ==<Snapshot, ChangeRepresentation>(
-	left: Expectation<[Delta<Snapshot, ChangeRepresentation>]>,
-	right: [Delta<Snapshot, ChangeRepresentation>]
-) where Snapshot.Iterator.Element: Equatable, ChangeRepresentation: Equatable {
+internal func ==<Delta: IndexingDelta>(
+	left: Expectation<Delta>,
+	right: Delta
+) where Delta.Snapshot.Iterator.Element: Equatable, Delta.ChangeRepresentation: Equatable, Delta.IndexPairs.Iterator.Element == (Delta.Snapshot.Index, Delta.Snapshot.Index) {
+	return left.to(NonNilMatcherFunc { expression, failureMessage in
+		let value = try expression.evaluate()!
+		if value == right {
+			return true
+		}
+
+		failureMessage.expected = "expected \(String(reflecting: right))"
+		failureMessage.to = ""
+		failureMessage.actualValue = String(reflecting: value)
+		return false
+	})
+}
+
+internal func ==<Delta: IndexingDelta>(
+	left: Expectation<[Delta]>,
+	right: [Delta]
+) where Delta.Snapshot.Iterator.Element: Equatable, Delta.ChangeRepresentation: Equatable, Delta.IndexPairs.Iterator.Element == (Delta.Snapshot.Index, Delta.Snapshot.Index) {
 	return left.to(NonNilMatcherFunc { expression, failureMessage in
 		let value = try expression.evaluate()!
 		if value.elementsEqual(right, by: ==) {
 			return true
 		}
 
-		failureMessage.expected = "expected \(right.debugDescription)"
+		failureMessage.expected = "expected \(String(reflecting: right))"
 		failureMessage.to = ""
-		failureMessage.actualValue = value.debugDescription
+		failureMessage.actualValue = String(reflecting: value)
 		return false
 	})
 }

--- a/Tests/ReactiveCollectionsTests/ReactiveArraySpec.swift
+++ b/Tests/ReactiveCollectionsTests/ReactiveArraySpec.swift
@@ -89,7 +89,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0[0] = 3 }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [3, 2, 3],
 						inserts: [],
@@ -115,7 +115,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.replaceSubrange(1...2, with: [1, 1]) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 1, 1],
 						inserts: [],
@@ -130,7 +130,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.replaceSubrange(0...1, with: [0, 0, 0]) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 1, 1],
 						current: [0, 0, 0, 1],
 						inserts: IndexSet(integer: 2),
@@ -145,7 +145,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.replaceSubrange(0...0, with: [1]) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [0, 0, 0, 1],
 						current: [1, 0, 0, 1],
 						inserts: [],
@@ -160,7 +160,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.replaceSubrange(array.indices, with: Array(0...5)) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 0, 0, 1],
 						current: [0, 1, 2, 3, 4, 5],
 						inserts: IndexSet(4...5),
@@ -184,7 +184,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.append(4) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2, 3, 4],
 						inserts: IndexSet(integer: 3),
@@ -208,7 +208,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.append(contentsOf: [4, 5, 6]) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2, 3, 4, 5, 6],
 						inserts: IndexSet(3..<6),
@@ -232,7 +232,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.insert(4, at: array.endIndex) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2, 3, 4],
 						inserts: IndexSet(integer: 3),
@@ -247,7 +247,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.insert(0, at: 0) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3, 4],
 						current: [0, 1, 2, 3, 4],
 						inserts: IndexSet(integer: 0),
@@ -271,7 +271,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.insert(contentsOf: [4, 5, 6], at: 0) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [4, 5, 6, 1, 2, 3],
 						inserts: IndexSet(0..<3),
@@ -295,7 +295,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeAll() }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [],
 						inserts: [],
@@ -319,7 +319,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeAll(keepingCapacity: true) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [],
 						inserts: [],
@@ -343,7 +343,7 @@ class ReactiveArraySpec: QuickSpec {
 				expect(array.modify { $0.removeFirst() }) == 1
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [2, 3],
 						inserts: [],
@@ -367,7 +367,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeFirst(2) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [3],
 						inserts: [],
@@ -391,7 +391,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeFirst(3) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [],
 						inserts: [],
@@ -415,7 +415,7 @@ class ReactiveArraySpec: QuickSpec {
 				expect(array.modify { $0.removeLast() }) == 3
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2],
 						inserts: [],
@@ -439,7 +439,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeLast(2) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1],
 						inserts: [],
@@ -463,7 +463,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeLast(3) }
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [],
 						inserts: [],
@@ -487,7 +487,7 @@ class ReactiveArraySpec: QuickSpec {
 				expect(array.modify { $0.remove(at: 1) }) == 2
 
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 3],
 						inserts: [],
@@ -511,7 +511,7 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeSubrange(1...2) }
 				
 				expectedChanges.append(
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1],
 						inserts: [],
@@ -567,7 +567,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == [8, 9, 0]
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: [8, 9, 0],
 					                             inserts: IndexSet(0 ..< 3),
 					                             deletes: IndexSet(0 ..< 3),
@@ -581,7 +581,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == [1, 2, 3]
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: [1, 2, 3],
 					                             inserts: [],
 					                             deletes: [],
@@ -595,7 +595,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == [1, 100, 2]
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: [1, 100, 2],
 					                             inserts: IndexSet(integer: 1),
 					                             deletes: IndexSet(integer: 2),
@@ -609,7 +609,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == [1, 100, 2, 200]
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: [1, 100, 2, 200],
 					                             inserts: IndexSet(integer: 1),
 					                             deletes: [],
@@ -627,7 +627,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == sorted
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: sorted,
 					                             inserts: IndexSet(integersIn: 3 ..< 11),
 					                             deletes: [],
@@ -646,7 +646,7 @@ class ReactiveArraySpec: QuickSpec {
 					}
 
 					expect(array) == sorted
-					expect(latestDelta) == Delta(previous: [1, 2, 3],
+					expect(latestDelta) == ArrayDelta(previous: [1, 2, 3],
 					                             current: sorted,
 					                             inserts: IndexSet(integersIn: 0 ..< 11),
 					                             deletes: IndexSet(integersIn: 0 ..< 3),
@@ -668,21 +668,21 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeAll() }
 
 				let expectedChanges: [Change<Int>] = [
-					Delta(
+					ArrayDelta(
 						previous: [],
 						current: [1, 2, 3],
 						inserts: IndexSet(0..<3),
 						deletes: [],
 						updates: []
 					),
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3],
 						current: [1, 2, 3, 4],
 						inserts: IndexSet(integer: 3),
 						deletes: [],
 						updates: []
 					),
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3, 4],
 						current: [],
 						inserts: [],
@@ -708,14 +708,14 @@ class ReactiveArraySpec: QuickSpec {
 				array.modify { $0.removeAll() }
 
 				let expectedChanges: [Change<Int>] = [
-					Delta(
+					ArrayDelta(
 						previous: [],
 						current: [1, 2, 3, 4],
 						inserts: IndexSet(0..<4),
 						deletes: [],
 						updates: []
 					),
-					Delta(
+					ArrayDelta(
 						previous: [1, 2, 3, 4],
 						current: [],
 						inserts: [],


### PR DESCRIPTION
## IndexingDelta and ArrayDelta

`IndexingDelta` is a protocol representing an atomic batch of changes applied to a collection with stable element order, in terms of the indices of the collection.

`ArrayDelta` is a concrete implementation of `StableCollectionDelta`, specifically for collections with array semantics that use `Int` for indices. It can be replaced by `Delta` with conditional conformance in Swift 4.

The protocol requires conforming types to guarantee a stable order of elements across deltas, such that consumers of the delta may safely derive integer offsets from the indices. In other words, given index *I* of delta *A* and index *J* of delta *B* referring to a certain position *P*, the derived offset of both index *I* and *J* must equal, provided that *P* has not been affected by any insertions or removals.

~~The protocol also requires conforming types to be able to represent the changes as ranges of indices. The implementation should enable assertions of full truncations and initial insertions by exposing a full index range, i.e. `startIndex ..< endIndex`.~~

It is modelled to support all kinds of `Collection` that can logically maintain a stable order of elements. Having said that, it is expected to work best with `RandomAccessCollection`.

The protocol is used in #19.

## The original Delta
Indexing delta on unordered collections is practically useless. Not only because the value would be the sole concern if these are to be observed, these also have non-trivial overhead to generate indices due to their index invalidation model.

So `Delta` is now reduced to record only inserts and deletes, which are the two most essential operations of collections.